### PR TITLE
[FEAT] 일별 집계 및 인사이트 자동 실행 경로 추가

### DIFF
--- a/src/main/java/com/sellerinsight/common/config/SchedulingConfig.java
+++ b/src/main/java/com/sellerinsight/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.sellerinsight.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/sellerinsight/pipeline/api/AdminDailyPipelineController.java
+++ b/src/main/java/com/sellerinsight/pipeline/api/AdminDailyPipelineController.java
@@ -1,0 +1,41 @@
+package com.sellerinsight.pipeline.api;
+
+import com.sellerinsight.common.api.ApiResponse;
+import com.sellerinsight.pipeline.api.dto.DailyPipelineRunResponse;
+import com.sellerinsight.pipeline.application.DailyPipelineExecutionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Tag(name = "Admin Pipeline", description = "운영용 일별 파이프라인 실행 API")
+@RestController
+@RequestMapping("/api/v1/admin/pipelines")
+@RequiredArgsConstructor
+public class AdminDailyPipelineController {
+
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+    private final DailyPipelineExecutionService dailyPipelineExecutionService;
+
+    @Operation(summary = "전체 판매자 대상 일별 집계 및 인사이트 생성 실행")
+    @PostMapping("/daily")
+    public ApiResponse<DailyPipelineRunResponse> runDailyPipeline(
+            @RequestParam(value = "date", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date
+    ) {
+        LocalDate targetDate = date != null
+                ? date
+                : LocalDate.now(ASIA_SEOUL).minusDays(1);
+
+        return ApiResponse.ok(dailyPipelineExecutionService.run(targetDate));
+    }
+}

--- a/src/main/java/com/sellerinsight/pipeline/api/dto/DailyPipelineRunResponse.java
+++ b/src/main/java/com/sellerinsight/pipeline/api/dto/DailyPipelineRunResponse.java
@@ -1,0 +1,14 @@
+package com.sellerinsight.pipeline.api.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DailyPipelineRunResponse(
+        LocalDate metricDate,
+        int totalSellerCount,
+        int processedSellerCount,
+        int failedSellerCount,
+        int generatedInsightCount,
+        List<Long> failedSellerIds
+) {
+}

--- a/src/main/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionService.java
+++ b/src/main/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionService.java
@@ -1,0 +1,67 @@
+package com.sellerinsight.pipeline.application;
+
+import com.sellerinsight.insight.api.dto.InsightsByDateResponse;
+import com.sellerinsight.insight.application.InsightGenerationService;
+import com.sellerinsight.metric.application.DailyMetricAggregationService;
+import com.sellerinsight.pipeline.api.dto.DailyPipelineRunResponse;
+import com.sellerinsight.seller.domain.Seller;
+import com.sellerinsight.seller.domain.SellerRepository;
+import com.sellerinsight.seller.domain.SellerStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyPipelineExecutionService {
+
+    private final SellerRepository sellerRepository;
+    private final DailyMetricAggregationService dailyMetricAggregationService;
+    private final InsightGenerationService insightGenerationService;
+
+    public DailyPipelineRunResponse run(LocalDate metricDate) {
+        List<Seller> sellers = sellerRepository.findAllByStatus(SellerStatus.CONNECTED);
+
+        int processedSellerCount = 0;
+        int failedSellerCount = 0;
+        int generatedInsightCount = 0;
+        List<Long> failedSellerIds = new ArrayList<>();
+
+        for (Seller seller : sellers) {
+            try {
+                dailyMetricAggregationService.aggregate(seller.getId(), metricDate);
+                InsightsByDateResponse insightResult = insightGenerationService.generate(
+                        seller.getId(),
+                        metricDate
+                );
+
+                processedSellerCount++;
+                generatedInsightCount += insightResult.insightCount();
+            } catch (Exception exception) {
+                failedSellerCount++;
+                failedSellerIds.add(seller.getId());
+
+                log.warn(
+                        "일별 파이프라인 실행 실패. sellerId={}, metricDate={}, message={}",
+                        seller.getId(),
+                        metricDate,
+                        exception.getMessage()
+                );
+            }
+        }
+
+        return new DailyPipelineRunResponse(
+                metricDate,
+                sellers.size(),
+                processedSellerCount,
+                failedSellerCount,
+                generatedInsightCount,
+                failedSellerIds
+        );
+    }
+}

--- a/src/main/java/com/sellerinsight/pipeline/schedule/DailyPipelineScheduler.java
+++ b/src/main/java/com/sellerinsight/pipeline/schedule/DailyPipelineScheduler.java
@@ -1,0 +1,39 @@
+package com.sellerinsight.pipeline.schedule;
+
+import com.sellerinsight.pipeline.api.dto.DailyPipelineRunResponse;
+import com.sellerinsight.pipeline.application.DailyPipelineExecutionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.pipeline.daily", name = "enabled", havingValue = "true")
+public class DailyPipelineScheduler {
+
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+    private final DailyPipelineExecutionService dailyPipelineExecutionService;
+
+    @Scheduled(cron = "${app.pipeline.daily.cron}", zone = "Asia/Seoul")
+    public void run() {
+        LocalDate targetDate = LocalDate.now(ASIA_SEOUL).minusDays(1);
+
+        DailyPipelineRunResponse result = dailyPipelineExecutionService.run(targetDate);
+
+        log.info(
+                "일별 파이프라인 실행 완료. metricDate={}, totalSellerCount={}, processedSellerCount={}, failedSellerCount={}, generatedInsightCount={}",
+                result.metricDate(),
+                result.totalSellerCount(),
+                result.processedSellerCount(),
+                result.failedSellerCount(),
+                result.generatedInsightCount()
+        );
+    }
+}

--- a/src/main/java/com/sellerinsight/seller/domain/SellerRepository.java
+++ b/src/main/java/com/sellerinsight/seller/domain/SellerRepository.java
@@ -2,6 +2,11 @@ package com.sellerinsight.seller.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SellerRepository extends JpaRepository<Seller, Long> {
+
     boolean existsByExternalSellerId(String externalSellerId);
+
+    List<Seller> findAllByStatus(SellerStatus status);
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,6 +16,9 @@ spring:
 app:
   security:
     encryption-key: 0123456789abcdef0123456789abcdef
+  pipeline:
+    daily:
+      enabled: false
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,6 @@ server:
       enabled: true
       force: true
 
-
 management:
   endpoints:
     web:
@@ -63,6 +62,12 @@ naver-commerce:
     token-path: /external/v1/oauth2/token
     connect-timeout-ms: 3000
     read-timeout-seconds: 5
+
+app:
+  pipeline:
+    daily:
+      enabled: true
+      cron: 0 5 2 * * *
 
 logging:
   level:

--- a/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
+++ b/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.sellerinsight.importjob.domain.ImportJob;
 import com.sellerinsight.importjob.domain.ImportJobRepository;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.RecommendationRepository;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
@@ -54,8 +56,16 @@ class ImportJobControllerTest {
     @Autowired
     private DailyMetricRepository dailyMetricRepository;
 
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @Autowired
+    private InsightRepository insightRepository;
+
     @BeforeEach
     void setUp() {
+        recommendationRepository.deleteAll();
+        insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();
         orderItemRepository.deleteAll();
         customerOrderRepository.deleteAll();

--- a/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
+++ b/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sellerinsight.importjob.domain.ImportJobRepository;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.RecommendationRepository;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrder;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
@@ -56,8 +58,16 @@ class DailyMetricControllerTest {
     @Autowired
     private SellerRepository sellerRepository;
 
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @Autowired
+    private InsightRepository insightRepository;
+
     @BeforeEach
     void setUp() {
+        recommendationRepository.deleteAll();
+        insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();
         orderItemRepository.deleteAll();
         customerOrderRepository.deleteAll();
@@ -195,4 +205,3 @@ class DailyMetricControllerTest {
                 .andExpect(jsonPath("$.data.staleProductCount").value(1));
     }
 }
-

--- a/src/test/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionServiceTest.java
+++ b/src/test/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionServiceTest.java
@@ -1,0 +1,82 @@
+package com.sellerinsight.pipeline.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import com.sellerinsight.insight.api.dto.InsightsByDateResponse;
+import com.sellerinsight.insight.application.InsightGenerationService;
+import com.sellerinsight.metric.application.DailyMetricAggregationService;
+import com.sellerinsight.pipeline.api.dto.DailyPipelineRunResponse;
+import com.sellerinsight.seller.domain.Seller;
+import com.sellerinsight.seller.domain.SellerRepository;
+import com.sellerinsight.seller.domain.SellerStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class DailyPipelineExecutionServiceTest {
+
+    @Mock
+    private SellerRepository sellerRepository;
+
+    @Mock
+    private DailyMetricAggregationService dailyMetricAggregationService;
+
+    @Mock
+    private InsightGenerationService insightGenerationService;
+
+    @Test
+    void runProcessesConnectedSellersAndContinuesOnFailure() {
+        Seller seller1 = mock(Seller.class);
+        Seller seller2 = mock(Seller.class);
+
+        when(seller1.getId()).thenReturn(1L);
+        when(seller2.getId()).thenReturn(2L);
+
+        LocalDate metricDate = LocalDate.of(2026, 4, 19);
+
+        when(sellerRepository.findAllByStatus(SellerStatus.CONNECTED))
+                .thenReturn(List.of(seller1, seller2));
+
+        when(insightGenerationService.generate(eq(1L), eq(metricDate)))
+                .thenReturn(new InsightsByDateResponse(1L, metricDate, 2, List.of()));
+
+        when(dailyMetricAggregationService.aggregate(anyLong(), eq(metricDate)))
+                .thenAnswer(invocation -> {
+                    Long sellerId = invocation.getArgument(0);
+
+                    if (sellerId.equals(2L)) {
+                        throw new IllegalStateException("aggregation failed");
+                    }
+
+                    return null;
+                });
+
+        DailyPipelineExecutionService service = new DailyPipelineExecutionService(
+                sellerRepository,
+                dailyMetricAggregationService,
+                insightGenerationService
+        );
+
+        DailyPipelineRunResponse result = service.run(metricDate);
+
+        assertThat(result.metricDate()).isEqualTo(metricDate);
+        assertThat(result.totalSellerCount()).isEqualTo(2);
+        assertThat(result.processedSellerCount()).isEqualTo(1);
+        assertThat(result.failedSellerCount()).isEqualTo(1);
+        assertThat(result.generatedInsightCount()).isEqualTo(2);
+        assertThat(result.failedSellerIds()).containsExactly(2L);
+
+        verify(dailyMetricAggregationService).aggregate(1L, metricDate);
+        verify(dailyMetricAggregationService).aggregate(2L, metricDate);
+        verify(insightGenerationService).generate(1L, metricDate);
+        verify(insightGenerationService, never()).generate(2L, metricDate);
+    }
+}

--- a/src/test/java/com/sellerinsight/seller/api/SellerControllerTest.java
+++ b/src/test/java/com/sellerinsight/seller/api/SellerControllerTest.java
@@ -2,6 +2,8 @@ package com.sellerinsight.seller.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sellerinsight.importjob.domain.ImportJobRepository;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.RecommendationRepository;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
@@ -56,8 +58,16 @@ class SellerControllerTest {
     @Autowired
     private DailyMetricRepository dailyMetricRepository;
 
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @Autowired
+    private InsightRepository insightRepository;
+
     @BeforeEach
     void setUp() {
+        recommendationRepository.deleteAll();
+        insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();
         orderItemRepository.deleteAll();
         customerOrderRepository.deleteAll();

--- a/src/test/java/com/sellerinsight/seller/api/SellerCredentialControllerTest.java
+++ b/src/test/java/com/sellerinsight/seller/api/SellerCredentialControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sellerinsight.common.security.CredentialEncryptor;
 import com.sellerinsight.importjob.domain.ImportJobRepository;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.RecommendationRepository;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
@@ -62,8 +64,16 @@ class SellerCredentialControllerTest {
     @Autowired
     private DailyMetricRepository dailyMetricRepository;
 
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @Autowired
+    private InsightRepository insightRepository;
+
     @BeforeEach
     void setUp() {
+        recommendationRepository.deleteAll();
+        insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();
         orderItemRepository.deleteAll();
         customerOrderRepository.deleteAll();


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [x] FEAT
- [ ] TASK

## 작업 요약
판매자별 수동 집계/인사이트 API와 별도로, 전체 판매자를 대상으로 일별 집계와 인사이트 생성을 한 번에 실행할 수 있는 자동화 경로를 추가했습니다.
현재는 운영용 수동 실행 API와 Scheduler 기반 자동 실행 구조를 함께 제공하도록 구성했습니다.

## 주요 변경점
- `SchedulingConfig` 추가
- `DailyPipelineExecutionService` 추가
- `AdminDailyPipelineController` 추가
- `DailyPipelineScheduler` 추가
- 파이프라인 실행 결과 응답 DTO 추가
- `SellerRepository`에 연결된 판매자 조회 메서드 추가
- `application.yml`, `application-test.yml`에 파이프라인 실행 설정 추가
- `DailyPipelineExecutionServiceTest` 추가
- 기존 통합 테스트의 FK 정리 순서에 `insights`, `recommendations` 반영

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [ ] 수동 확인

## 이슈
- Closes #13 