### PR TITLE
[FEAT] 판매자 대시보드 조회 API 추가

### DIFF
--- a/src/main/java/com/sellerinsight/dashboard/api/DashboardController.java
+++ b/src/main/java/com/sellerinsight/dashboard/api/DashboardController.java
@@ -1,0 +1,66 @@
+package com.sellerinsight.dashboard.api;
+
+import com.sellerinsight.common.api.ApiResponse;
+import com.sellerinsight.dashboard.api.dto.DashboardMetricRangeResponse;
+import com.sellerinsight.dashboard.api.dto.DashboardResponse;
+import com.sellerinsight.dashboard.api.dto.RecentInsightsResponse;
+import com.sellerinsight.dashboard.application.DashboardQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@Tag(name = "Dashboard", description = "판매자 대시보드 조회 API")
+@RestController
+@RequestMapping("/api/v1/sellers/{sellerId}/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardQueryService dashboardQueryService;
+
+    @Operation(summary = "판매자 대시보드 조회")
+    @GetMapping
+    public ApiResponse<DashboardResponse> getDashboard(
+            @PathVariable Long sellerId,
+            @RequestParam(value = "metricDays", defaultValue = "7") int metricDays,
+            @RequestParam(value = "insightLimit", defaultValue = "5") int insightLimit
+    ) {
+        return ApiResponse.ok(
+                dashboardQueryService.getDashboard(sellerId, metricDays, insightLimit)
+        );
+    }
+
+    @Operation(summary = "대시보드용 일별 지표 범위 조회")
+    @GetMapping("/metrics")
+    public ApiResponse<DashboardMetricRangeResponse> getMetricRange(
+            @PathVariable Long sellerId,
+            @RequestParam("from")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate from,
+            @RequestParam("to")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate to
+    ) {
+        return ApiResponse.ok(
+                dashboardQueryService.getMetricRange(sellerId, from, to)
+        );
+    }
+
+    @Operation(summary = "대시보드용 최근 인사이트 조회")
+    @GetMapping("/insights/recent")
+    public ApiResponse<RecentInsightsResponse> getRecentInsights(
+            @PathVariable Long sellerId,
+            @RequestParam(value = "limit", defaultValue = "5") int limit
+    ) {
+        return ApiResponse.ok(
+                dashboardQueryService.getRecentInsights(sellerId, limit)
+        );
+    }
+}

--- a/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardInsightSummaryResponse.java
+++ b/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardInsightSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.sellerinsight.dashboard.api.dto;
+
+public record DashboardInsightSummaryResponse(
+        long totalCount,
+        long lowCount,
+        long mediumCount,
+        long highCount
+) {
+    public static DashboardInsightSummaryResponse of(
+            long lowCount,
+            long mediumCount,
+            long highCount
+    ) {
+        return new DashboardInsightSummaryResponse(
+                lowCount + mediumCount + highCount,
+                lowCount,
+                mediumCount,
+                highCount
+        );
+    }
+}

--- a/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardMetricPointResponse.java
+++ b/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardMetricPointResponse.java
@@ -1,0 +1,26 @@
+package com.sellerinsight.dashboard.api.dto;
+
+import com.sellerinsight.metric.domain.DailyMetric;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record DashboardMetricPointResponse(
+        LocalDate metricDate,
+        int orderCount,
+        BigDecimal salesAmount,
+        BigDecimal averageOrderAmount,
+        int soldOutProductCount,
+        int staleProductCount
+) {
+    public static DashboardMetricPointResponse from(DailyMetric dailyMetric) {
+        return new DashboardMetricPointResponse(
+                dailyMetric.getMetricDate(),
+                dailyMetric.getOrderCount(),
+                dailyMetric.getSalesAmount(),
+                dailyMetric.getAverageOrderAmount(),
+                dailyMetric.getSoldOutProductCount(),
+                dailyMetric.getStaleProductCount()
+        );
+    }
+}

--- a/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardMetricRangeResponse.java
+++ b/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardMetricRangeResponse.java
@@ -1,0 +1,13 @@
+package com.sellerinsight.dashboard.api.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DashboardMetricRangeResponse(
+        Long sellerId,
+        LocalDate from,
+        LocalDate to,
+        int metricCount,
+        List<DashboardMetricPointResponse> metrics
+) {
+}

--- a/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardResponse.java
+++ b/src/main/java/com/sellerinsight/dashboard/api/dto/DashboardResponse.java
@@ -1,0 +1,21 @@
+package com.sellerinsight.dashboard.api.dto;
+
+import com.sellerinsight.insight.api.dto.InsightResponse;
+import com.sellerinsight.metric.api.dto.DailyMetricResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DashboardResponse(
+        Long sellerId,
+        String sellerName,
+        LocalDate latestMetricDate,
+        DailyMetricResponse latestMetric,
+        int metricTrendDays,
+        List<DashboardMetricPointResponse> metricTrend,
+        DashboardInsightSummaryResponse insightSummary,
+        int recentInsightCount,
+        List<InsightResponse> recentInsights,
+        SellerPipelineStatusResponse latestPipelineStatus
+) {
+}

--- a/src/main/java/com/sellerinsight/dashboard/api/dto/RecentInsightsResponse.java
+++ b/src/main/java/com/sellerinsight/dashboard/api/dto/RecentInsightsResponse.java
@@ -1,0 +1,13 @@
+package com.sellerinsight.dashboard.api.dto;
+
+import com.sellerinsight.insight.api.dto.InsightResponse;
+
+import java.util.List;
+
+public record RecentInsightsResponse(
+        Long sellerId,
+        int limit,
+        int insightCount,
+        List<InsightResponse> insights
+) {
+}

--- a/src/main/java/com/sellerinsight/dashboard/api/dto/SellerPipelineStatusResponse.java
+++ b/src/main/java/com/sellerinsight/dashboard/api/dto/SellerPipelineStatusResponse.java
@@ -1,0 +1,32 @@
+package com.sellerinsight.dashboard.api.dto;
+
+import com.sellerinsight.pipeline.domain.PipelineRunItem;
+import com.sellerinsight.pipeline.domain.PipelineRunItemStatus;
+import com.sellerinsight.pipeline.domain.PipelineTriggerType;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+public record SellerPipelineStatusResponse(
+        Long runId,
+        LocalDate metricDate,
+        PipelineTriggerType triggerType,
+        PipelineRunItemStatus status,
+        int generatedInsightCount,
+        String errorMessage,
+        OffsetDateTime startedAt,
+        OffsetDateTime endedAt
+) {
+    public static SellerPipelineStatusResponse from(PipelineRunItem pipelineRunItem) {
+        return new SellerPipelineStatusResponse(
+                pipelineRunItem.getPipelineRun().getId(),
+                pipelineRunItem.getPipelineRun().getMetricDate(),
+                pipelineRunItem.getPipelineRun().getTriggerType(),
+                pipelineRunItem.getStatus(),
+                pipelineRunItem.getGeneratedInsightCount(),
+                pipelineRunItem.getErrorMessage(),
+                pipelineRunItem.getStartedAt(),
+                pipelineRunItem.getEndedAt()
+        );
+    }
+}

--- a/src/main/java/com/sellerinsight/dashboard/application/DashboardQueryService.java
+++ b/src/main/java/com/sellerinsight/dashboard/application/DashboardQueryService.java
@@ -1,0 +1,170 @@
+package com.sellerinsight.dashboard.application;
+
+import com.sellerinsight.common.error.BusinessException;
+import com.sellerinsight.common.error.ErrorCode;
+import com.sellerinsight.dashboard.api.dto.DashboardInsightSummaryResponse;
+import com.sellerinsight.dashboard.api.dto.DashboardMetricPointResponse;
+import com.sellerinsight.dashboard.api.dto.DashboardMetricRangeResponse;
+import com.sellerinsight.dashboard.api.dto.DashboardResponse;
+import com.sellerinsight.dashboard.api.dto.RecentInsightsResponse;
+import com.sellerinsight.dashboard.api.dto.SellerPipelineStatusResponse;
+import com.sellerinsight.insight.api.dto.InsightResponse;
+import com.sellerinsight.insight.api.dto.RecommendationResponse;
+import com.sellerinsight.insight.domain.Insight;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.InsightSeverity;
+import com.sellerinsight.insight.domain.RecommendationRepository;
+import com.sellerinsight.metric.api.dto.DailyMetricResponse;
+import com.sellerinsight.metric.domain.DailyMetric;
+import com.sellerinsight.metric.domain.DailyMetricRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.seller.domain.Seller;
+import com.sellerinsight.seller.domain.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardQueryService {
+
+    private final SellerRepository sellerRepository;
+    private final DailyMetricRepository dailyMetricRepository;
+    private final InsightRepository insightRepository;
+    private final RecommendationRepository recommendationRepository;
+    private final PipelineRunItemRepository pipelineRunItemRepository;
+
+    public DashboardResponse getDashboard(
+            Long sellerId,
+            int metricDays,
+            int insightLimit
+    ) {
+        Seller seller = getSeller(sellerId);
+
+        int safeMetricDays = Math.max(metricDays, 1);
+        int safeInsightLimit = Math.max(insightLimit, 1);
+
+        Optional<DailyMetric> latestMetricOptional = dailyMetricRepository
+                .findFirstBySellerIdOrderByMetricDateDesc(sellerId);
+
+        List<DashboardMetricPointResponse> metricTrend = latestMetricOptional
+                .map(latestMetric -> getMetricPoints(
+                        sellerId,
+                        latestMetric.getMetricDate().minusDays(safeMetricDays - 1L),
+                        latestMetric.getMetricDate()
+                ))
+                .orElse(List.of());
+
+        List<InsightResponse> recentInsights = getRecentInsightsInternal(sellerId, safeInsightLimit);
+
+        DashboardInsightSummaryResponse insightSummary = DashboardInsightSummaryResponse.of(
+                insightRepository.countBySellerIdAndSeverity(sellerId, InsightSeverity.LOW),
+                insightRepository.countBySellerIdAndSeverity(sellerId, InsightSeverity.MEDIUM),
+                insightRepository.countBySellerIdAndSeverity(sellerId, InsightSeverity.HIGH)
+        );
+
+        SellerPipelineStatusResponse latestPipelineStatus = pipelineRunItemRepository
+                .findFirstBySellerIdOrderByIdDesc(sellerId)
+                .map(SellerPipelineStatusResponse::from)
+                .orElse(null);
+
+        return new DashboardResponse(
+                seller.getId(),
+                seller.getSellerName(),
+                latestMetricOptional.map(DailyMetric::getMetricDate).orElse(null),
+                latestMetricOptional.map(DailyMetricResponse::from).orElse(null),
+                safeMetricDays,
+                metricTrend,
+                insightSummary,
+                recentInsights.size(),
+                recentInsights,
+                latestPipelineStatus
+        );
+    }
+
+    public DashboardMetricRangeResponse getMetricRange(
+            Long sellerId,
+            LocalDate from,
+            LocalDate to
+    ) {
+        getSeller(sellerId);
+
+        if (from.isAfter(to)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        List<DashboardMetricPointResponse> metrics = getMetricPoints(sellerId, from, to);
+
+        return new DashboardMetricRangeResponse(
+                sellerId,
+                from,
+                to,
+                metrics.size(),
+                metrics
+        );
+    }
+
+    public RecentInsightsResponse getRecentInsights(Long sellerId, int limit) {
+        getSeller(sellerId);
+
+        int safeLimit = Math.max(limit, 1);
+        List<InsightResponse> insights = getRecentInsightsInternal(sellerId, safeLimit);
+
+        return new RecentInsightsResponse(
+                sellerId,
+                safeLimit,
+                insights.size(),
+                insights
+        );
+    }
+
+    private Seller getSeller(Long sellerId) {
+        return sellerRepository.findById(sellerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private List<DashboardMetricPointResponse> getMetricPoints(
+            Long sellerId,
+            LocalDate from,
+            LocalDate to
+    ) {
+        return dailyMetricRepository.findAllBySellerIdAndMetricDateBetweenOrderByMetricDateAsc(
+                        sellerId,
+                        from,
+                        to
+                ).stream()
+                .map(DashboardMetricPointResponse::from)
+                .toList();
+    }
+
+    private List<InsightResponse> getRecentInsightsInternal(Long sellerId, int limit) {
+        PageRequest pageRequest = PageRequest.of(
+                0,
+                limit,
+                Sort.by(
+                        Sort.Order.desc("metricDate"),
+                        Sort.Order.desc("id")
+                )
+        );
+
+        return insightRepository.findAllBySellerId(sellerId, pageRequest).stream()
+                .map(this::toInsightResponse)
+                .toList();
+    }
+
+    private InsightResponse toInsightResponse(Insight insight) {
+        List<RecommendationResponse> recommendations = recommendationRepository
+                .findAllByInsightIdOrderByPriorityAsc(insight.getId()).stream()
+                .map(RecommendationResponse::from)
+                .toList();
+
+        return InsightResponse.from(insight, recommendations);
+    }
+}

--- a/src/main/java/com/sellerinsight/insight/domain/InsightRepository.java
+++ b/src/main/java/com/sellerinsight/insight/domain/InsightRepository.java
@@ -1,5 +1,6 @@
 package com.sellerinsight.insight.domain;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -15,6 +16,10 @@ public interface InsightRepository extends JpaRepository<Insight, Long> {
     );
 
     List<Insight> findAllBySellerIdAndMetricDateOrderByIdAsc(Long sellerId, LocalDate metricDate);
+
+    List<Insight> findAllBySellerId(Long sellerId, Pageable pageable);
+
+    long countBySellerIdAndSeverity(Long sellerId, InsightSeverity severity);
 
     Optional<Insight> findByIdAndSellerId(Long id, Long sellerId);
 }

--- a/src/main/java/com/sellerinsight/metric/domain/DailyMetricRepository.java
+++ b/src/main/java/com/sellerinsight/metric/domain/DailyMetricRepository.java
@@ -3,9 +3,18 @@ package com.sellerinsight.metric.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface DailyMetricRepository extends JpaRepository<DailyMetric, Long> {
 
     Optional<DailyMetric> findBySellerIdAndMetricDate(Long sellerId, LocalDate metricDate);
+
+    Optional<DailyMetric> findFirstBySellerIdOrderByMetricDateDesc(Long sellerId);
+
+    List<DailyMetric> findAllBySellerIdAndMetricDateBetweenOrderByMetricDateAsc(
+            Long sellerId,
+            LocalDate from,
+            LocalDate to
+    );
 }

--- a/src/main/java/com/sellerinsight/pipeline/domain/PipelineRunItemRepository.java
+++ b/src/main/java/com/sellerinsight/pipeline/domain/PipelineRunItemRepository.java
@@ -3,8 +3,11 @@ package com.sellerinsight.pipeline.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PipelineRunItemRepository extends JpaRepository<PipelineRunItem, Long> {
 
     List<PipelineRunItem> findAllByPipelineRunIdOrderByIdAsc(Long pipelineRunId);
+
+    Optional<PipelineRunItem> findFirstBySellerIdOrderByIdDesc(Long sellerId);
 }

--- a/src/test/java/com/sellerinsight/dashboard/api/DashboardControllerTest.java
+++ b/src/test/java/com/sellerinsight/dashboard/api/DashboardControllerTest.java
@@ -1,0 +1,269 @@
+package com.sellerinsight.dashboard.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sellerinsight.importjob.domain.ImportJobRepository;
+import com.sellerinsight.insight.domain.Insight;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.InsightSeverity;
+import com.sellerinsight.insight.domain.InsightType;
+import com.sellerinsight.insight.domain.Recommendation;
+import com.sellerinsight.insight.domain.RecommendationRepository;
+import com.sellerinsight.metric.domain.DailyMetric;
+import com.sellerinsight.metric.domain.DailyMetricRepository;
+import com.sellerinsight.order.domain.CustomerOrderRepository;
+import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRun;
+import com.sellerinsight.pipeline.domain.PipelineRunItem;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunStatus;
+import com.sellerinsight.pipeline.domain.PipelineTriggerType;
+import com.sellerinsight.pipeline.domain.PipelineType;
+import com.sellerinsight.product.domain.ProductRepository;
+import com.sellerinsight.seller.domain.Seller;
+import com.sellerinsight.seller.domain.SellerCredentialRepository;
+import com.sellerinsight.seller.domain.SellerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DashboardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PipelineRunItemRepository pipelineRunItemRepository;
+
+    @Autowired
+    private PipelineRunRepository pipelineRunRepository;
+
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @Autowired
+    private InsightRepository insightRepository;
+
+    @Autowired
+    private DailyMetricRepository dailyMetricRepository;
+
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+
+    @Autowired
+    private CustomerOrderRepository customerOrderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ImportJobRepository importJobRepository;
+
+    @Autowired
+    private SellerCredentialRepository sellerCredentialRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @BeforeEach
+    void setUp() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
+        recommendationRepository.deleteAll();
+        insightRepository.deleteAll();
+        dailyMetricRepository.deleteAll();
+        orderItemRepository.deleteAll();
+        customerOrderRepository.deleteAll();
+        productRepository.deleteAll();
+        importJobRepository.deleteAll();
+        sellerCredentialRepository.deleteAll();
+        sellerRepository.deleteAll();
+    }
+
+    @Test
+    void getDashboardAndDashboardSubResources() throws Exception {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("seller-001", "sellerinsight-store")
+        );
+
+        dailyMetricRepository.saveAndFlush(
+                DailyMetric.create(
+                        seller,
+                        LocalDate.of(2026, 4, 14),
+                        3,
+                        new BigDecimal("30000"),
+                        new BigDecimal("10000"),
+                        0,
+                        2
+                )
+        );
+
+        dailyMetricRepository.saveAndFlush(
+                DailyMetric.create(
+                        seller,
+                        LocalDate.of(2026, 4, 15),
+                        4,
+                        new BigDecimal("40000"),
+                        new BigDecimal("10000"),
+                        1,
+                        1
+                )
+        );
+
+        dailyMetricRepository.saveAndFlush(
+                DailyMetric.create(
+                        seller,
+                        LocalDate.of(2026, 4, 16),
+                        5,
+                        new BigDecimal("50000"),
+                        new BigDecimal("10000"),
+                        2,
+                        1
+                )
+        );
+
+        Insight mediumInsight = insightRepository.saveAndFlush(
+                Insight.create(
+                        seller,
+                        LocalDate.of(2026, 4, 15),
+                        InsightType.SOLD_OUT_RISK,
+                        InsightSeverity.MEDIUM,
+                        "품절 상품이 존재합니다.",
+                        "중간 위험도 인사이트",
+                        "{\"soldOutProductCount\":1}",
+                        "SoldOutRiskRule"
+                )
+        );
+
+        recommendationRepository.saveAndFlush(
+                Recommendation.create(
+                        mediumInsight,
+                        1,
+                        "CHECK_STOCK",
+                        "재고를 확인하세요.",
+                        "품절 상품의 재고를 먼저 확인하세요.",
+                        "SoldOutRiskRule"
+                )
+        );
+
+        Insight highInsight = insightRepository.saveAndFlush(
+                Insight.create(
+                        seller,
+                        LocalDate.of(2026, 4, 16),
+                        InsightType.ORDER_DROP,
+                        InsightSeverity.HIGH,
+                        "전일 대비 주문 수가 감소했습니다.",
+                        "고위험도 인사이트",
+                        "{\"changeRate\":-50.0}",
+                        "OrderDropRule"
+                )
+        );
+
+        recommendationRepository.saveAndFlush(
+                Recommendation.create(
+                        highInsight,
+                        1,
+                        "CHECK_TOP_PRODUCTS",
+                        "주문 감소 상품을 확인하세요.",
+                        "주문 감소 원인을 우선 확인하세요.",
+                        "OrderDropRule"
+                )
+        );
+
+        Insight lowInsight = insightRepository.saveAndFlush(
+                Insight.create(
+                        seller,
+                        LocalDate.of(2026, 4, 16),
+                        InsightType.SOLD_OUT_RISK,
+                        InsightSeverity.LOW,
+                        "품절 상품이 일부 존재합니다.",
+                        "저위험도 인사이트",
+                        "{\"soldOutProductCount\":2}",
+                        "SoldOutRiskRule"
+                )
+        );
+
+        recommendationRepository.saveAndFlush(
+                Recommendation.create(
+                        lowInsight,
+                        1,
+                        "RESTOCK_PRIORITY",
+                        "보충 우선순위를 확인하세요.",
+                        "우선순위가 높은 상품부터 보충하세요.",
+                        "SoldOutRiskRule"
+                )
+        );
+
+        PipelineRun pipelineRun = PipelineRun.start(
+                PipelineType.DAILY,
+                PipelineTriggerType.SCHEDULED,
+                LocalDate.of(2026, 4, 16)
+        );
+        pipelineRun.complete(PipelineRunStatus.SUCCESS, 1, 1, 0, 2);
+
+        PipelineRun savedPipelineRun = pipelineRunRepository.saveAndFlush(pipelineRun);
+
+        pipelineRunItemRepository.saveAndFlush(
+                PipelineRunItem.success(savedPipelineRun, seller, 2)
+        );
+
+        mockMvc.perform(
+                        get("/api/v1/sellers/{sellerId}/dashboard", seller.getId())
+                                .param("metricDays", "3")
+                                .param("insightLimit", "2")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sellerId").value(seller.getId()))
+                .andExpect(jsonPath("$.data.sellerName").value("sellerinsight-store"))
+                .andExpect(jsonPath("$.data.latestMetricDate").value("2026-04-16"))
+                .andExpect(jsonPath("$.data.latestMetric.orderCount").value(5))
+                .andExpect(jsonPath("$.data.metricTrendDays").value(3))
+                .andExpect(jsonPath("$.data.metricTrend.length()").value(3))
+                .andExpect(jsonPath("$.data.insightSummary.totalCount").value(3))
+                .andExpect(jsonPath("$.data.insightSummary.lowCount").value(1))
+                .andExpect(jsonPath("$.data.insightSummary.mediumCount").value(1))
+                .andExpect(jsonPath("$.data.insightSummary.highCount").value(1))
+                .andExpect(jsonPath("$.data.recentInsightCount").value(2))
+                .andExpect(jsonPath("$.data.recentInsights.length()").value(2))
+                .andExpect(jsonPath("$.data.latestPipelineStatus.metricDate").value("2026-04-16"))
+                .andExpect(jsonPath("$.data.latestPipelineStatus.triggerType").value("SCHEDULED"))
+                .andExpect(jsonPath("$.data.latestPipelineStatus.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.latestPipelineStatus.generatedInsightCount").value(2));
+
+        mockMvc.perform(
+                        get("/api/v1/sellers/{sellerId}/dashboard/metrics", seller.getId())
+                                .param("from", "2026-04-14")
+                                .param("to", "2026-04-16")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.metricCount").value(3))
+                .andExpect(jsonPath("$.data.metrics[0].metricDate").value("2026-04-14"))
+                .andExpect(jsonPath("$.data.metrics[2].metricDate").value("2026-04-16"));
+
+        mockMvc.perform(
+                        get("/api/v1/sellers/{sellerId}/dashboard/insights/recent", seller.getId())
+                                .param("limit", "2")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.limit").value(2))
+                .andExpect(jsonPath("$.data.insightCount").value(2))
+                .andExpect(jsonPath("$.data.insights[0].metricDate").value("2026-04-16"))
+                .andExpect(jsonPath("$.data.insights[1].metricDate").value("2026-04-16"));
+    }
+}

--- a/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
+++ b/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
@@ -13,6 +13,8 @@ import com.sellerinsight.insight.domain.RecommendationRepository;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.domain.Seller;
 import com.sellerinsight.seller.domain.SellerCredentialRepository;
@@ -62,8 +64,16 @@ class ImportJobControllerTest {
     @Autowired
     private InsightRepository insightRepository;
 
+    @Autowired
+    private PipelineRunItemRepository pipelineRunItemRepository;
+
+    @Autowired
+    private PipelineRunRepository pipelineRunRepository;
+
     @BeforeEach
     void setUp() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
         recommendationRepository.deleteAll();
         insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();

--- a/src/test/java/com/sellerinsight/insight/api/InsightControllerTest.java
+++ b/src/test/java/com/sellerinsight/insight/api/InsightControllerTest.java
@@ -12,6 +12,8 @@ import com.sellerinsight.metric.domain.DailyMetric;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.domain.Seller;
 import com.sellerinsight.seller.domain.SellerCredentialRepository;
@@ -62,8 +64,16 @@ class InsightControllerTest {
     @Autowired
     private SellerRepository sellerRepository;
 
+    @Autowired
+    private PipelineRunItemRepository pipelineRunItemRepository;
+
+    @Autowired
+    private PipelineRunRepository pipelineRunRepository;
+
     @BeforeEach
     void setUp() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
         recommendationRepository.deleteAll();
         insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();

--- a/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
+++ b/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
@@ -13,6 +13,8 @@ import com.sellerinsight.order.domain.CustomerOrder;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItem;
 import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
 import com.sellerinsight.product.domain.Product;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.domain.Seller;
@@ -64,8 +66,16 @@ class DailyMetricControllerTest {
     @Autowired
     private InsightRepository insightRepository;
 
+    @Autowired
+    private PipelineRunItemRepository pipelineRunItemRepository;
+
+    @Autowired
+    private PipelineRunRepository pipelineRunRepository;
+
     @BeforeEach
     void setUp() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
         recommendationRepository.deleteAll();
         insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();

--- a/src/test/java/com/sellerinsight/seller/api/SellerControllerTest.java
+++ b/src/test/java/com/sellerinsight/seller/api/SellerControllerTest.java
@@ -7,6 +7,8 @@ import com.sellerinsight.insight.domain.RecommendationRepository;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.api.dto.CreateSellerRequest;
 import com.sellerinsight.seller.domain.Seller;
@@ -64,8 +66,16 @@ class SellerControllerTest {
     @Autowired
     private InsightRepository insightRepository;
 
+    @Autowired
+    private PipelineRunItemRepository pipelineRunItemRepository;
+
+    @Autowired
+    private PipelineRunRepository pipelineRunRepository;
+
     @BeforeEach
     void setUp() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
         recommendationRepository.deleteAll();
         insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();

--- a/src/test/java/com/sellerinsight/seller/api/SellerCredentialControllerTest.java
+++ b/src/test/java/com/sellerinsight/seller/api/SellerCredentialControllerTest.java
@@ -14,6 +14,8 @@ import com.sellerinsight.insight.domain.RecommendationRepository;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.api.dto.UpsertSellerCredentialRequest;
 import com.sellerinsight.seller.domain.Seller;
@@ -70,8 +72,16 @@ class SellerCredentialControllerTest {
     @Autowired
     private InsightRepository insightRepository;
 
+    @Autowired
+    private PipelineRunItemRepository pipelineRunItemRepository;
+
+    @Autowired
+    private PipelineRunRepository pipelineRunRepository;
+
     @BeforeEach
     void setUp() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
         recommendationRepository.deleteAll();
         insightRepository.deleteAll();
         dailyMetricRepository.deleteAll();


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [x] FEAT
- [ ] TASK

## 작업 요약
적재된 일별 지표, 생성된 인사이트, 최근 파이프라인 실행 상태를 한 번에 조회할 수 있는 판매자 대시보드 API를 추가했습니다.
대시보드 메인 조회 외에도 기간별 지표 추이와 최근 인사이트 목록을 별도 API로 조회할 수 있도록 구성했습니다.

## 주요 변경점
- `DashboardResponse`, `DashboardMetricPointResponse`, `DashboardMetricRangeResponse`, `RecentInsightsResponse`, `DashboardInsightSummaryResponse`, `SellerPipelineStatusResponse` 추가
- `DashboardQueryService` 추가
- `DashboardController` 추가
- `GET /api/v1/sellers/{sellerId}/dashboard` 추가
- `GET /api/v1/sellers/{sellerId}/dashboard/metrics` 추가
- `GET /api/v1/sellers/{sellerId}/dashboard/insights/recent` 추가
- `DailyMetricRepository`, `InsightRepository`, `PipelineRunItemRepository`에 대시보드 조회용 메서드 추가
- `DashboardControllerTest` 추가
- 기존 통합 테스트 정리 순서에 `pipeline_run_items`, `pipeline_runs` 반영
- 잘못된 `Pageable` import 및 누락된 반환 로직 정리

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #17 