### PR TITLE
[FEAT] 샘플 데이터 시드 및 전체 사이클 스모크 검증 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@
 - 공통 응답 포맷 및 글로벌 예외 처리
 - Health Check API
 - Seller / SellerCredential 예제 도메인
+- 주문 CSV 적재 및 import job 상태 추적
+- 일별 지표 집계, 규칙 기반 인사이트 생성, 파이프라인 실행 이력 저장
+- 판매자 대시보드 조회 API
+- 로컬 시연용 샘플 데이터 시드 API
 - Swagger 문서화
 - 메트릭 및 로그 수집 기반 관측 스택
 - Grafana 기본 대시보드
@@ -111,6 +115,28 @@ docker compose -f docker-compose.observability.yml up -d
 ```bash
 ./gradlew test
 ```
+
+## 데모 실행 흐름
+
+```bash
+docker compose up -d
+./gradlew bootRun
+```
+
+```bash
+curl -X POST "http://localhost:8080/api/v1/admin/sample-data/bootstrap?scenario=default"
+```
+
+응답의 `targetMetricDate`, `sellerId`를 확인한 뒤:
+
+```bash
+curl -X POST "http://localhost:8080/api/v1/admin/pipelines/daily?date={previousMetricDate}"
+curl -X POST "http://localhost:8080/api/v1/admin/pipelines/daily?date={targetMetricDate}"
+curl "http://localhost:8080/api/v1/sellers/{sellerId}/dashboard"
+curl "http://localhost:8080/api/v1/admin/pipelines/daily/runs?limit=5"
+```
+
+`ORDER_DROP` 규칙까지 보려면 `previousMetricDate`를 먼저 집계한 뒤 `targetMetricDate`를 실행해야 합니다.
 
 ## 문서
 

--- a/src/main/java/com/sellerinsight/sampledata/api/AdminSampleDataController.java
+++ b/src/main/java/com/sellerinsight/sampledata/api/AdminSampleDataController.java
@@ -1,0 +1,29 @@
+package com.sellerinsight.sampledata.api;
+
+import com.sellerinsight.common.api.ApiResponse;
+import com.sellerinsight.sampledata.api.dto.SampleDataBootstrapResponse;
+import com.sellerinsight.sampledata.application.SampleDataBootstrapService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin Sample Data", description = "운영용 샘플 데이터 주입 API")
+@RestController
+@RequestMapping("/api/v1/admin/sample-data")
+@RequiredArgsConstructor
+public class AdminSampleDataController {
+
+    private final SampleDataBootstrapService sampleDataBootstrapService;
+
+    @Operation(summary = "기존 데이터를 초기화하고 샘플 데이터를 주입")
+    @PostMapping("/bootstrap")
+    public ApiResponse<SampleDataBootstrapResponse> bootstrap(
+            @RequestParam(value = "scenario", defaultValue = "default") String scenario
+    ) {
+        return ApiResponse.ok(sampleDataBootstrapService.bootstrap(scenario));
+    }
+}

--- a/src/main/java/com/sellerinsight/sampledata/api/dto/SampleDataBootstrapResponse.java
+++ b/src/main/java/com/sellerinsight/sampledata/api/dto/SampleDataBootstrapResponse.java
@@ -1,0 +1,16 @@
+package com.sellerinsight.sampledata.api.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record SampleDataBootstrapResponse(
+        String scenario,
+        LocalDate previousMetricDate,
+        LocalDate targetMetricDate,
+        int sellerCount,
+        int productCount,
+        int orderCount,
+        int orderItemCount,
+        List<SampleDataSellerResponse> sellers
+) {
+}

--- a/src/main/java/com/sellerinsight/sampledata/api/dto/SampleDataSellerResponse.java
+++ b/src/main/java/com/sellerinsight/sampledata/api/dto/SampleDataSellerResponse.java
@@ -1,0 +1,10 @@
+package com.sellerinsight.sampledata.api.dto;
+
+public record SampleDataSellerResponse(
+        Long sellerId,
+        String externalSellerId,
+        String sellerName,
+        int productCount,
+        int orderCount
+) {
+}

--- a/src/main/java/com/sellerinsight/sampledata/application/SampleDataBootstrapService.java
+++ b/src/main/java/com/sellerinsight/sampledata/application/SampleDataBootstrapService.java
@@ -1,0 +1,373 @@
+package com.sellerinsight.sampledata.application;
+
+import com.sellerinsight.common.error.BusinessException;
+import com.sellerinsight.common.error.ErrorCode;
+import com.sellerinsight.importjob.domain.ImportJobRepository;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.RecommendationRepository;
+import com.sellerinsight.metric.domain.DailyMetricRepository;
+import com.sellerinsight.order.domain.CustomerOrder;
+import com.sellerinsight.order.domain.CustomerOrderRepository;
+import com.sellerinsight.order.domain.OrderItem;
+import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
+import com.sellerinsight.product.domain.Product;
+import com.sellerinsight.product.domain.ProductRepository;
+import com.sellerinsight.sampledata.api.dto.SampleDataBootstrapResponse;
+import com.sellerinsight.sampledata.api.dto.SampleDataSellerResponse;
+import com.sellerinsight.seller.domain.Seller;
+import com.sellerinsight.seller.domain.SellerCredentialRepository;
+import com.sellerinsight.seller.domain.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SampleDataBootstrapService {
+
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+    private static final String DEFAULT_SCENARIO = "default";
+
+    private final PipelineRunItemRepository pipelineRunItemRepository;
+    private final PipelineRunRepository pipelineRunRepository;
+    private final RecommendationRepository recommendationRepository;
+    private final InsightRepository insightRepository;
+    private final DailyMetricRepository dailyMetricRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final CustomerOrderRepository customerOrderRepository;
+    private final ProductRepository productRepository;
+    private final ImportJobRepository importJobRepository;
+    private final SellerCredentialRepository sellerCredentialRepository;
+    private final SellerRepository sellerRepository;
+
+    public SampleDataBootstrapResponse bootstrap(String scenario) {
+        String normalizedScenario = scenario == null ? DEFAULT_SCENARIO : scenario.trim().toLowerCase();
+
+        if (!DEFAULT_SCENARIO.equals(normalizedScenario)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        clearExistingData();
+
+        LocalDate targetMetricDate = LocalDate.now(ASIA_SEOUL).minusDays(1);
+        LocalDate previousMetricDate = targetMetricDate.minusDays(1);
+        LocalDate recentMetricDate = targetMetricDate.minusDays(10);
+        LocalDate staleMetricDate = targetMetricDate.minusDays(20);
+
+        SellerSeedResult alpha = seedAlphaSeller(
+                previousMetricDate,
+                targetMetricDate,
+                recentMetricDate,
+                staleMetricDate
+        );
+        SellerSeedResult beta = seedBetaSeller(
+                previousMetricDate,
+                targetMetricDate,
+                recentMetricDate
+        );
+
+        List<SampleDataSellerResponse> sellers = List.of(
+                new SampleDataSellerResponse(
+                        alpha.seller().getId(),
+                        alpha.seller().getExternalSellerId(),
+                        alpha.seller().getSellerName(),
+                        alpha.productCount(),
+                        alpha.orderCount()
+                ),
+                new SampleDataSellerResponse(
+                        beta.seller().getId(),
+                        beta.seller().getExternalSellerId(),
+                        beta.seller().getSellerName(),
+                        beta.productCount(),
+                        beta.orderCount()
+                )
+        );
+
+        return new SampleDataBootstrapResponse(
+                normalizedScenario,
+                previousMetricDate,
+                targetMetricDate,
+                sellers.size(),
+                alpha.productCount() + beta.productCount(),
+                alpha.orderCount() + beta.orderCount(),
+                alpha.orderItemCount() + beta.orderItemCount(),
+                sellers
+        );
+    }
+
+    private void clearExistingData() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
+        recommendationRepository.deleteAll();
+        insightRepository.deleteAll();
+        dailyMetricRepository.deleteAll();
+        orderItemRepository.deleteAll();
+        customerOrderRepository.deleteAll();
+        productRepository.deleteAll();
+        importJobRepository.deleteAll();
+        sellerCredentialRepository.deleteAll();
+        sellerRepository.deleteAll();
+    }
+
+    private SellerSeedResult seedAlphaSeller(
+            LocalDate previousMetricDate,
+            LocalDate targetMetricDate,
+            LocalDate recentMetricDate,
+            LocalDate staleMetricDate
+    ) {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("sample-seller-alpha", "sample-store-alpha")
+        );
+
+        Product mainProduct = productRepository.saveAndFlush(
+                Product.create(
+                        seller,
+                        "ALPHA-PROD-001",
+                        "Alpha 베스트셀러",
+                        new BigDecimal("15000"),
+                        12,
+                        "ON_SALE"
+                )
+        );
+        Product soldOutProduct = productRepository.saveAndFlush(
+                Product.create(
+                        seller,
+                        "ALPHA-PROD-002",
+                        "Alpha 품절 상품",
+                        new BigDecimal("23000"),
+                        0,
+                        "SOLD_OUT"
+                )
+        );
+        Product staleProduct = productRepository.saveAndFlush(
+                Product.create(
+                        seller,
+                        "ALPHA-PROD-003",
+                        "Alpha 장기 미판매 상품",
+                        new BigDecimal("18000"),
+                        7,
+                        "ON_SALE"
+                )
+        );
+
+        int orderCount = 0;
+        int orderItemCount = 0;
+
+        for (int sequence = 1; sequence <= 3; sequence++) {
+            createSingleItemOrder(
+                    seller,
+                    mainProduct,
+                    previousMetricDate,
+                    sequence,
+                    10 + sequence,
+                    1,
+                    new BigDecimal("15000")
+            );
+            orderCount++;
+            orderItemCount++;
+        }
+
+        for (int sequence = 4; sequence <= 5; sequence++) {
+            createSingleItemOrder(
+                    seller,
+                    soldOutProduct,
+                    previousMetricDate,
+                    sequence,
+                    10 + sequence,
+                    1,
+                    new BigDecimal("23000")
+            );
+            orderCount++;
+            orderItemCount++;
+        }
+
+        for (int sequence = 6; sequence <= 7; sequence++) {
+            createSingleItemOrder(
+                    seller,
+                    mainProduct,
+                    targetMetricDate,
+                    sequence,
+                    11 + sequence,
+                    1,
+                    new BigDecimal("15000")
+            );
+            orderCount++;
+            orderItemCount++;
+        }
+
+        createSingleItemOrder(
+                seller,
+                mainProduct,
+                recentMetricDate,
+                8,
+                15,
+                1,
+                new BigDecimal("15000")
+        );
+        orderCount++;
+        orderItemCount++;
+
+        createSingleItemOrder(
+                seller,
+                staleProduct,
+                staleMetricDate,
+                9,
+                13,
+                1,
+                new BigDecimal("18000")
+        );
+        orderCount++;
+        orderItemCount++;
+
+        return new SellerSeedResult(seller, 3, orderCount, orderItemCount);
+    }
+
+    private SellerSeedResult seedBetaSeller(
+            LocalDate previousMetricDate,
+            LocalDate targetMetricDate,
+            LocalDate recentMetricDate
+    ) {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("sample-seller-beta", "sample-store-beta")
+        );
+
+        Product mainProduct = productRepository.saveAndFlush(
+                Product.create(
+                        seller,
+                        "BETA-PROD-001",
+                        "Beta 대표 상품",
+                        new BigDecimal("12000"),
+                        14,
+                        "ON_SALE"
+                )
+        );
+        Product secondaryProduct = productRepository.saveAndFlush(
+                Product.create(
+                        seller,
+                        "BETA-PROD-002",
+                        "Beta 보조 상품",
+                        new BigDecimal("9000"),
+                        20,
+                        "ON_SALE"
+                )
+        );
+
+        int orderCount = 0;
+        int orderItemCount = 0;
+
+        createSingleItemOrder(
+                seller,
+                mainProduct,
+                previousMetricDate,
+                1,
+                10,
+                1,
+                new BigDecimal("12000")
+        );
+        orderCount++;
+        orderItemCount++;
+
+        createSingleItemOrder(
+                seller,
+                secondaryProduct,
+                previousMetricDate,
+                2,
+                11,
+                1,
+                new BigDecimal("9000")
+        );
+        orderCount++;
+        orderItemCount++;
+
+        createSingleItemOrder(
+                seller,
+                mainProduct,
+                targetMetricDate,
+                3,
+                12,
+                1,
+                new BigDecimal("12000")
+        );
+        orderCount++;
+        orderItemCount++;
+
+        createSingleItemOrder(
+                seller,
+                secondaryProduct,
+                targetMetricDate,
+                4,
+                13,
+                1,
+                new BigDecimal("9000")
+        );
+        orderCount++;
+        orderItemCount++;
+
+        createSingleItemOrder(
+                seller,
+                mainProduct,
+                recentMetricDate,
+                5,
+                14,
+                1,
+                new BigDecimal("12000")
+        );
+        orderCount++;
+        orderItemCount++;
+
+        return new SellerSeedResult(seller, 2, orderCount, orderItemCount);
+    }
+
+    private void createSingleItemOrder(
+            Seller seller,
+            Product product,
+            LocalDate orderDate,
+            int sequence,
+            int hour,
+            int quantity,
+            BigDecimal unitPrice
+    ) {
+        BigDecimal itemAmount = unitPrice.multiply(BigDecimal.valueOf(quantity));
+        OffsetDateTime orderedAt = orderDate.atTime(hour, 0)
+                .atZone(ASIA_SEOUL)
+                .toOffsetDateTime();
+
+        CustomerOrder customerOrder = customerOrderRepository.saveAndFlush(
+                CustomerOrder.create(
+                        seller,
+                        seller.getExternalSellerId() + "-ORD-" + sequence + "-" + orderDate,
+                        orderedAt,
+                        "PAID",
+                        itemAmount
+                )
+        );
+
+        orderItemRepository.saveAndFlush(
+                OrderItem.create(
+                        customerOrder,
+                        product,
+                        seller.getExternalSellerId() + "-ITEM-" + sequence + "-" + orderDate,
+                        quantity,
+                        unitPrice,
+                        itemAmount
+                )
+        );
+    }
+
+    private record SellerSeedResult(
+            Seller seller,
+            int productCount,
+            int orderCount,
+            int orderItemCount
+    ) {
+    }
+}

--- a/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
+++ b/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
@@ -1,0 +1,181 @@
+package com.sellerinsight.sampledata.api;
+
+import com.sellerinsight.importjob.domain.ImportJobRepository;
+import com.sellerinsight.insight.domain.InsightRepository;
+import com.sellerinsight.insight.domain.RecommendationRepository;
+import com.sellerinsight.metric.domain.DailyMetricRepository;
+import com.sellerinsight.order.domain.CustomerOrderRepository;
+import com.sellerinsight.order.domain.OrderItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
+import com.sellerinsight.pipeline.domain.PipelineRunRepository;
+import com.sellerinsight.product.domain.ProductRepository;
+import com.sellerinsight.seller.domain.Seller;
+import com.sellerinsight.seller.domain.SellerCredentialRepository;
+import com.sellerinsight.seller.domain.SellerRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminSampleDataControllerTest {
+
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PipelineRunItemRepository pipelineRunItemRepository;
+
+    @Autowired
+    private PipelineRunRepository pipelineRunRepository;
+
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @Autowired
+    private InsightRepository insightRepository;
+
+    @Autowired
+    private DailyMetricRepository dailyMetricRepository;
+
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+
+    @Autowired
+    private CustomerOrderRepository customerOrderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ImportJobRepository importJobRepository;
+
+    @Autowired
+    private SellerCredentialRepository sellerCredentialRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @BeforeEach
+    void setUp() {
+        pipelineRunItemRepository.deleteAll();
+        pipelineRunRepository.deleteAll();
+        recommendationRepository.deleteAll();
+        insightRepository.deleteAll();
+        dailyMetricRepository.deleteAll();
+        orderItemRepository.deleteAll();
+        customerOrderRepository.deleteAll();
+        productRepository.deleteAll();
+        importJobRepository.deleteAll();
+        sellerCredentialRepository.deleteAll();
+        sellerRepository.deleteAll();
+    }
+
+    @Test
+    void bootstrapSampleDataAndRunFullCycle() throws Exception {
+        LocalDate previousMetricDate = LocalDate.now(ASIA_SEOUL).minusDays(2);
+        LocalDate targetMetricDate = LocalDate.now(ASIA_SEOUL).minusDays(1);
+
+        mockMvc.perform(
+                        post("/api/v1/admin/sample-data/bootstrap")
+                                .param("scenario", "default")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.scenario").value("default"))
+                .andExpect(jsonPath("$.data.targetMetricDate").value(targetMetricDate.toString()))
+                .andExpect(jsonPath("$.data.sellerCount").value(2))
+                .andExpect(jsonPath("$.data.productCount").value(5))
+                .andExpect(jsonPath("$.data.orderCount").value(14))
+                .andExpect(jsonPath("$.data.orderItemCount").value(14))
+                .andExpect(jsonPath("$.data.sellers.length()").value(2));
+
+        mockMvc.perform(
+                        post("/api/v1/admin/pipelines/daily")
+                                .param("date", previousMetricDate.toString())
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.metricDate").value(previousMetricDate.toString()))
+                .andExpect(jsonPath("$.data.totalSellerCount").value(2))
+                .andExpect(jsonPath("$.data.processedSellerCount").value(2))
+                .andExpect(jsonPath("$.data.failedSellerCount").value(0));
+
+        mockMvc.perform(
+                        post("/api/v1/admin/pipelines/daily")
+                                .param("date", targetMetricDate.toString())
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.metricDate").value(targetMetricDate.toString()))
+                .andExpect(jsonPath("$.data.totalSellerCount").value(2))
+                .andExpect(jsonPath("$.data.processedSellerCount").value(2))
+                .andExpect(jsonPath("$.data.failedSellerCount").value(0))
+                .andExpect(jsonPath("$.data.generatedInsightCount").value(2))
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+
+        Seller alphaSeller = sellerRepository.findAll().stream()
+                .filter(seller -> "sample-seller-alpha".equals(seller.getExternalSellerId()))
+                .findFirst()
+                .orElseThrow();
+
+        mockMvc.perform(
+                        get("/api/v1/sellers/{sellerId}/dashboard", alphaSeller.getId())
+                                .param("metricDays", "7")
+                                .param("insightLimit", "5")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sellerId").value(alphaSeller.getId()))
+                .andExpect(jsonPath("$.data.latestMetricDate").value(targetMetricDate.toString()))
+                .andExpect(jsonPath("$.data.latestMetric.orderCount").value(2))
+                .andExpect(jsonPath("$.data.latestMetric.soldOutProductCount").value(1))
+                .andExpect(jsonPath("$.data.latestMetric.staleProductCount").value(1))
+                .andExpect(jsonPath("$.data.insightSummary.totalCount").value(3))
+                .andExpect(jsonPath("$.data.latestPipelineStatus.status").value("SUCCESS"));
+
+        mockMvc.perform(
+                        get("/api/v1/sellers/{sellerId}/dashboard/insights/recent", alphaSeller.getId())
+                                .param("limit", "5")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.insightCount").value(3));
+
+        mockMvc.perform(
+                        get("/api/v1/admin/pipelines/daily/runs")
+                                .param("limit", "1")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].metricDate").value(targetMetricDate.toString()))
+                .andExpect(jsonPath("$.data[0].status").value("SUCCESS"));
+
+        Long runId = pipelineRunRepository.findAllByPipelineTypeOrderByIdDesc(
+                com.sellerinsight.pipeline.domain.PipelineType.DAILY
+        ).get(0).getId();
+
+        mockMvc.perform(
+                        get("/api/v1/admin/pipelines/daily/runs/{runId}", runId)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.itemCount").value(2))
+                .andExpect(jsonPath("$.data.items.length()").value(2));
+    }
+}


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [x] FEAT
- [ ] TASK

## 작업 요약
샘플 데이터 시드 기능을 추가해 로컬/데모 환경에서 원천 데이터부터 집계, 인사이트, 대시보드, 파이프라인 실행 이력까지 전체 사이클을 검증할 수 있도록 구성했습니다.
또한 샘플 데이터 주입 후 실제 파이프라인을 순서대로 실행하는 스모크 테스트와 README 데모 흐름을 함께 보강했습니다.

## 주요 변경점
- `SampleDataBootstrapService` 추가
- `AdminSampleDataController` 추가
- `SampleDataBootstrapResponse`, `SampleDataSellerResponse` 추가
- 샘플 판매자/상품/주문/주문아이템 시드 로직 추가
- `AdminSampleDataControllerTest` 추가
- 전일 집계 후 대상일 집계를 실행하는 전체 사이클 스모크 테스트 추가
- README에 샘플 데이터 기반 데모 실행 흐름 추가
- Swagger/수동 테스트용 CSV 파일 `docs/orders-insight-test.csv` 추가

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #19 