### PR TITLE
[FEAT] API 기본 인증 도입 및 관리자 엔드포인트 보호

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.mindrot:jbcrypt:0.4'
 
+    // SECURITY
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
@@ -85,6 +88,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'com.h2database:h2'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sellerinsight/common/config/ApiSecurityProperties.java
+++ b/src/main/java/com/sellerinsight/common/config/ApiSecurityProperties.java
@@ -1,0 +1,15 @@
+package com.sellerinsight.common.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "app.api-security")
+public record ApiSecurityProperties(
+        @NotBlank String adminUsername,
+        @NotBlank String adminPassword,
+        @NotBlank String sellerUsername,
+        @NotBlank String sellerPassword
+) {
+}

--- a/src/main/java/com/sellerinsight/common/config/OpenApiConfig.java
+++ b/src/main/java/com/sellerinsight/common/config/OpenApiConfig.java
@@ -1,9 +1,12 @@
 package com.sellerinsight.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,6 +16,15 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI sellerInsightOpenApi() {
         return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes(
+                                "basicAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("basic")
+                        )
+                )
+                .addSecurityItem(new SecurityRequirement().addList("basicAuth"))
                 .info(new Info()
                         .title("Seller Insight API")
                         .description("네이버 커머스 연동 판매자 인사이트 백엔드 API")

--- a/src/main/java/com/sellerinsight/common/config/SecurityConfig.java
+++ b/src/main/java/com/sellerinsight/common/config/SecurityConfig.java
@@ -1,9 +1,72 @@
 package com.sellerinsight.common.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-@EnableConfigurationProperties(SecurityProperties.class)
+@EnableConfigurationProperties({
+        SecurityProperties.class,
+        ApiSecurityProperties.class
+})
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(Customizer.withDefaults())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/error",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .requestMatchers(
+                                "/api/v1/health",
+                                "/actuator/health",
+                                "/actuator/info",
+                                "/actuator/prometheus"
+                        ).permitAll()
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/**").hasAnyRole("SELLER", "ADMIN")
+                        .anyRequest().authenticated()
+                );
+
+                return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(
+            ApiSecurityProperties properties,
+            PasswordEncoder passwordEncoder
+    ) {
+        return new InMemoryUserDetailsManager(
+                User.withUsername(properties.adminUsername())
+                        .password(passwordEncoder.encode(properties.adminPassword()))
+                        .roles("ADMIN")
+                        .build(),
+                User.withUsername(properties.sellerUsername())
+                        .password(passwordEncoder.encode(properties.sellerPassword()))
+                        .roles("SELLER")
+                        .build()
+        );
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 }

--- a/src/main/java/com/sellerinsight/sampledata/api/AdminSampleDataController.java
+++ b/src/main/java/com/sellerinsight/sampledata/api/AdminSampleDataController.java
@@ -6,11 +6,13 @@ import com.sellerinsight.sampledata.application.SampleDataBootstrapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Profile({"local", "test", "demo"})
 @Tag(name = "Admin Sample Data", description = "운영용 샘플 데이터 주입 API")
 @RestController
 @RequestMapping("/api/v1/admin/sample-data")

--- a/src/main/resources/application-demo.yml
+++ b/src/main/resources/application-demo.yml
@@ -1,17 +1,7 @@
 spring:
   config:
     activate:
-      on-profile: docker
-
-  datasource:
-    url: jdbc:postgresql://${DB_HOST:postgres}:${DB_PORT:5432}/${DB_NAME:sellerinsight}
-    username: ${DB_USERNAME:sellerinsight}
-    password: ${DB_PASSWORD:sellerinsight}
-    driver-class-name: org.postgresql.Driver
-
-  sql:
-    init:
-      mode: never
+      on-profile: demo
 
 app:
   security:
@@ -22,6 +12,10 @@ app:
     admin-password: ${APP_ADMIN_PASSWORD:admin-1234}
     seller-username: ${APP_SELLER_USERNAME:seller-demo}
     seller-password: ${APP_SELLER_PASSWORD:seller-demo-1234}
+
+  pipeline:
+    daily:
+      enabled: false
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,12 @@ app:
   security:
     encryption-key: ${APP_ENCRYPTION_KEY:0123456789abcdef0123456789abcdef}
 
+  api-security:
+    admin-username: ${APP_ADMIN_USERNAME:admin}
+    admin-password: ${APP_ADMIN_PASSWORD:admin-1234}
+    seller-username: ${APP_SELLER_USERNAME:seller-demo}
+    seller-password: ${APP_SELLER_PASSWORD:seller-demo-1234}
+
 logging:
   level:
     com.sellerinsight: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,12 @@ app:
   security:
     encryption-key: ${APP_ENCRYPTION_KEY}
 
+  api-security:
+    admin-username: ${APP_ADMIN_USERNAME}
+    admin-password: ${APP_ADMIN_PASSWORD}
+    seller-username: ${APP_SELLER_USERNAME}
+    seller-password: ${APP_SELLER_PASSWORD}
+
 server:
   forward-headers-strategy: framework
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,6 +16,13 @@ spring:
 app:
   security:
     encryption-key: 0123456789abcdef0123456789abcdef
+
+  api-security:
+    admin-username: admin
+    admin-password: admin-1234
+    seller-username: seller-demo
+    seller-password: seller-demo-1234
+
   pipeline:
     daily:
       enabled: false

--- a/src/test/java/com/sellerinsight/dashboard/api/DashboardControllerTest.java
+++ b/src/test/java/com/sellerinsight/dashboard/api/DashboardControllerTest.java
@@ -38,7 +38,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class DashboardControllerTest {
 

--- a/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
+++ b/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class ImportJobControllerTest {
 

--- a/src/test/java/com/sellerinsight/insight/api/InsightControllerTest.java
+++ b/src/test/java/com/sellerinsight/insight/api/InsightControllerTest.java
@@ -30,7 +30,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class InsightControllerTest {
 

--- a/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
+++ b/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
@@ -32,7 +32,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class DailyMetricControllerTest {
 

--- a/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
+++ b/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class AdminSampleDataControllerTest {
 

--- a/src/test/java/com/sellerinsight/security/api/ApiSecurityIntegrationTest.java
+++ b/src/test/java/com/sellerinsight/security/api/ApiSecurityIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.sellerinsight.security.api;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ApiSecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthApiIsPublic() throws Exception {
+        mockMvc.perform(get("/api/v1/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void sellerApiRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/sellers/9999"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void sellerUserCanAccessSellerApi() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/sellers/9999")
+                                .with(httpBasic("seller-demo", "seller-demo-1234"))
+                )
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void sellerUserCannotAccessAdminApi() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/admin/pipelines/daily/runs")
+                                .param("limit", "1")
+                                .with(httpBasic("seller-demo", "seller-demo-1234"))
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void adminUserCanAccessAdminApi() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/admin/pipelines/daily/runs")
+                                .param("limit", "1")
+                                .with(httpBasic("admin", "admin-1234"))
+                )
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/sellerinsight/seller/api/SellerControllerTest.java
+++ b/src/test/java/com/sellerinsight/seller/api/SellerControllerTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class SellerControllerTest {
 

--- a/src/test/java/com/sellerinsight/seller/api/SellerCredentialControllerTest.java
+++ b/src/test/java/com/sellerinsight/seller/api/SellerCredentialControllerTest.java
@@ -32,7 +32,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class SellerCredentialControllerTest {
 


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [x] FEAT
- [ ] TASK

## 작업 요약
Spring Security 기반 Basic Auth를 도입해 관리자 API와 일반 API를 역할 단위로 분리했습니다.
또한 Swagger에서 인증 정보를 바로 입력해 테스트할 수 있도록 OpenAPI 보안 스키마를 추가했고, 샘플 데이터 API는 비운영 프로필에서만 활성화되도록 제한했습니다.

## 주요 변경점
- `spring-boot-starter-security`, `spring-security-test` 의존성 추가
- `ApiSecurityProperties` 추가
- `SecurityConfig`에 Basic Auth, 역할 기반 접근 제어, in-memory 사용자 설정 추가
- `application-local.yml`, `application-test.yml`, `application-docker.yml`, `application-prod.yml`, `application-demo.yml`에 API 보안 계정 설정 추가
- `OpenApiConfig`에 `basicAuth` 보안 스키마 추가
- `AdminSampleDataController`에 `@Profile({"local", "test", "demo"})` 적용
- 기존 비즈니스 통합 테스트를 `@AutoConfigureMockMvc(addFilters = false)`로 분리
- `ApiSecurityIntegrationTest` 추가
- 공개/인증/권한 분리 응답 코드 검증 추가

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #21 