### PR TITLE
[FEAT] CSV 업로드 정책 강화 및 상품 최신성 보호 기능 추가

### DIFF
--- a/src/main/java/com/sellerinsight/common/error/ErrorCode.java
+++ b/src/main/java/com/sellerinsight/common/error/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     IMPORT_JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "IMPORT_404_1", "가져오기 작업을 찾을 수 없습니다."),
     CSV_IMPORT_INVALID_FILE(HttpStatus.BAD_REQUEST, "IMPORT_400_1", "CSV 파일이 비어 있거나 형식이 올바르지 않습니다."),
     CSV_IMPORT_FAILED(HttpStatus.BAD_REQUEST, "IMPORT_400_2", "CSV 가져오기에 실패했습니다."),
+    CSV_IMPORT_INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "IMPORT_400_3", "허용되지 않은 CSV 파일 형식입니다."),
+    CSV_IMPORT_FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "IMPORT_413_1", "업로드 가능한 CSV 파일 크기를 초과했습니다."),
 
     DAILY_METRIC_NOT_FOUND(HttpStatus.NOT_FOUND, "METRIC_404_1", "일별 지표를 찾을 수 없습니다."),
     INSIGHT_NOT_FOUND(HttpStatus.NOT_FOUND, "INSIGHT_404_1", "인사이트를 찾을 수 없습니다."),

--- a/src/main/java/com/sellerinsight/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/sellerinsight/common/error/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -63,6 +64,17 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(ErrorCode.DUPLICATE_RESOURCE.getStatus())
+                .body(ApiResponse.fail(errorResponse));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException(
+            MaxUploadSizeExceededException exception
+    ) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.CSV_IMPORT_FILE_TOO_LARGE);
+
+        return ResponseEntity
+                .status(ErrorCode.CSV_IMPORT_FILE_TOO_LARGE.getStatus())
                 .body(ApiResponse.fail(errorResponse));
     }
 

--- a/src/main/java/com/sellerinsight/importjob/application/CsvFileValidator.java
+++ b/src/main/java/com/sellerinsight/importjob/application/CsvFileValidator.java
@@ -1,0 +1,50 @@
+package com.sellerinsight.importjob.application;
+
+import com.sellerinsight.common.error.BusinessException;
+import com.sellerinsight.common.error.ErrorCode;
+import com.sellerinsight.importjob.config.CsvImportProperties;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class CsvFileValidator {
+
+    private final CsvImportProperties csvImportProperties;
+
+    public void validate(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.CSV_IMPORT_INVALID_FILE);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null
+                || originalFilename.isBlank()
+                || !originalFilename.toLowerCase(Locale.ROOT).endsWith(".csv")) {
+            throw new BusinessException(ErrorCode.CSV_IMPORT_INVALID_FILE_TYPE);
+        }
+
+        if (file.getSize() > csvImportProperties.maxFileSize().toBytes()) {
+            throw new BusinessException(ErrorCode.CSV_IMPORT_FILE_TOO_LARGE);
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || contentType.isBlank()) {
+            return;
+        }
+
+        String normalizedContentType = contentType.toLowerCase(Locale.ROOT)
+                .split(";")[0]
+                .trim();
+
+        boolean allowed = csvImportProperties.allowedContentTypes().stream()
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .anyMatch(normalizedContentType::equals);
+
+        if (!allowed) {
+            throw new BusinessException(ErrorCode.CSV_IMPORT_INVALID_FILE_TYPE);
+        }
+    }
+}

--- a/src/main/java/com/sellerinsight/importjob/application/CsvImportProcessingException.java
+++ b/src/main/java/com/sellerinsight/importjob/application/CsvImportProcessingException.java
@@ -1,0 +1,24 @@
+package com.sellerinsight.importjob.application;
+
+import lombok.Getter;
+
+@Getter
+public class CsvImportProcessingException extends RuntimeException {
+
+    private final int totalRowCount;
+    private final int successRowCount;
+    private final int failedRowCount;
+
+    public CsvImportProcessingException(
+            int totalRowCount,
+            int successRowCount,
+            int failedRowCount,
+            String message,
+            Throwable cause
+    ) {
+        super(message, cause);
+        this.totalRowCount = totalRowCount;
+        this.successRowCount = successRowCount;
+        this.failedRowCount = failedRowCount;
+    }
+}

--- a/src/main/java/com/sellerinsight/importjob/application/OrderCsvImportProcessor.java
+++ b/src/main/java/com/sellerinsight/importjob/application/OrderCsvImportProcessor.java
@@ -12,20 +12,20 @@ import com.sellerinsight.product.domain.Product;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.domain.Seller;
 import com.sellerinsight.seller.domain.SellerRepository;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @RequiredArgsConstructor
@@ -63,6 +63,7 @@ public class OrderCsvImportProcessor {
         importJob.markProcessing();
 
         int totalRowCount = 0;
+        int successRowCount = 0;
 
         try (
                 Reader reader = new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8);
@@ -79,40 +80,56 @@ public class OrderCsvImportProcessor {
             for (CSVRecord record : parser) {
                 totalRowCount++;
                 importRecord(seller, record);
+                successRowCount++;
             }
 
-            importJob.markSuccess(totalRowCount, totalRowCount, 0);
+            importJob.markSuccess(totalRowCount, successRowCount, 0);
         } catch (IOException exception) {
-            throw new BusinessException(ErrorCode.CSV_IMPORT_FAILED);
-        } catch (IllegalArgumentException exception) {
-            throw new BusinessException(ErrorCode.CSV_IMPORT_FAILED);
+            throw new CsvImportProcessingException(
+                    totalRowCount,
+                    successRowCount,
+                    calculateFailedRowCount(totalRowCount, successRowCount),
+                    ErrorCode.CSV_IMPORT_FAILED.getMessage(),
+                    exception
+            );
+        } catch (BusinessException | IllegalArgumentException exception) {
+            throw new CsvImportProcessingException(
+                    totalRowCount,
+                    successRowCount,
+                    calculateFailedRowCount(totalRowCount, successRowCount),
+                    exception.getMessage(),
+                    exception
+            );
         }
     }
 
     private void validateHeaders(CSVParser parser) {
         Set<String> actualHeaders = parser.getHeaderMap().keySet();
 
-        if (!actualHeaders.containsAll(REQUIRED_HEADERS)) {
+        if (actualHeaders.size() != REQUIRED_HEADERS.size() || !actualHeaders.containsAll(REQUIRED_HEADERS)) {
             throw new BusinessException(ErrorCode.CSV_IMPORT_INVALID_FILE);
         }
     }
 
     private void importRecord(Seller seller, CSVRecord record) {
-        Product product = upsertProduct(seller, record);
-        CustomerOrder customerOrder = upsertOrder(seller, record);
+        OffsetDateTime orderedAt = parseOffsetDateTime(record, "orderedAt");
+
+        Product product = upsertProduct(seller, record, orderedAt);
+        CustomerOrder customerOrder = upsertOrder(seller, record, orderedAt);
         upsertOrderItem(customerOrder, product, record);
     }
 
-    private Product upsertProduct(Seller seller, CSVRecord record) {
+    private Product upsertProduct(Seller seller, CSVRecord record, OffsetDateTime orderedAt) {
         String externalProductId = requireText(record, "productId");
         String productName = requireText(record, "productName");
-        BigDecimal salePrice = parseBigDecimal(record, "salePrice");
-        Integer stockQuantity = parseInteger(record, "stockQuantity");
+        BigDecimal salePrice = parseNonNegativeBigDecimal(record, "salePrice");
+        Integer stockQuantity = parseNonNegativeInteger(record, "stockQuantity");
         String productStatus = requireText(record, "productStatus");
 
         return productRepository.findBySellerIdAndExternalProductId(seller.getId(), externalProductId)
                 .map(existingProduct -> {
                     existingProduct.updateFromImport(
+                            orderedAt,
                             productName,
                             salePrice,
                             stockQuantity,
@@ -127,16 +144,16 @@ public class OrderCsvImportProcessor {
                                 productName,
                                 salePrice,
                                 stockQuantity,
-                                productStatus
+                                productStatus,
+                                orderedAt
                         )
                 ));
     }
 
-    private CustomerOrder upsertOrder(Seller seller, CSVRecord record) {
+    private CustomerOrder upsertOrder(Seller seller, CSVRecord record, OffsetDateTime orderedAt) {
         String externalOrderNo = requireText(record, "orderNo");
-        OffsetDateTime orderedAt = parseOffsetDateTime(record, "orderedAt");
         String orderStatus = requireText(record, "orderStatus");
-        BigDecimal totalAmount = parseBigDecimal(record, "totalAmount");
+        BigDecimal totalAmount = parseNonNegativeBigDecimal(record, "totalAmount");
 
         return customerOrderRepository.findBySellerIdAndExternalOrderNo(seller.getId(), externalOrderNo)
                 .map(existingOrder -> {
@@ -164,9 +181,9 @@ public class OrderCsvImportProcessor {
             CSVRecord record
     ) {
         String externalOrderItemNo = requireText(record, "orderItemNo");
-        Integer quantity = parseInteger(record, "quantity");
-        BigDecimal unitPrice = parseBigDecimal(record, "unitPrice");
-        BigDecimal itemAmount = parseBigDecimal(record, "itemAmount");
+        Integer quantity = parsePositiveInteger(record, "quantity");
+        BigDecimal unitPrice = parseNonNegativeBigDecimal(record, "unitPrice");
+        BigDecimal itemAmount = parseNonNegativeBigDecimal(record, "itemAmount");
 
         orderItemRepository.findByCustomerOrderIdAndExternalOrderItemNo(
                         customerOrder.getId(),
@@ -196,21 +213,67 @@ public class OrderCsvImportProcessor {
         String value = record.get(columnName);
 
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException(columnName + " 값이 비어 있습니다.");
+            throw invalidValue(record, columnName + " 값이 비어 있습니다.");
         }
 
         return value;
     }
 
-    private Integer parseInteger(CSVRecord record, String columnName) {
-        return Integer.parseInt(requireText(record, columnName));
+    private Integer parsePositiveInteger(CSVRecord record, String columnName) {
+        int value = parseInteger(record, columnName);
+
+        if (value <= 0) {
+            throw invalidValue(record, columnName + " 값은 0보다 커야 합니다.");
+        }
+
+        return value;
     }
 
-    private BigDecimal parseBigDecimal(CSVRecord record, String columnName) {
-        return new BigDecimal(requireText(record, columnName));
+    private Integer parseNonNegativeInteger(CSVRecord record, String columnName) {
+        int value = parseInteger(record, columnName);
+
+        if (value < 0) {
+            throw invalidValue(record, columnName + " 값은 0 이상이어야 합니다.");
+        }
+
+        return value;
+    }
+
+    private int parseInteger(CSVRecord record, String columnName) {
+        try {
+            return Integer.parseInt(requireText(record, columnName));
+        } catch (NumberFormatException exception) {
+            throw invalidValue(record, columnName + " 값은 정수여야 합니다.");
+        }
+    }
+
+    private BigDecimal parseNonNegativeBigDecimal(CSVRecord record, String columnName) {
+        try {
+            BigDecimal value = new BigDecimal(requireText(record, columnName));
+
+            if (value.compareTo(BigDecimal.ZERO) < 0) {
+                throw invalidValue(record, columnName + " 값은 0 이상이어야 합니다.");
+            }
+
+            return value;
+        } catch (NumberFormatException exception) {
+            throw invalidValue(record, columnName + " 값은 숫자여야 합니다.");
+        }
     }
 
     private OffsetDateTime parseOffsetDateTime(CSVRecord record, String columnName) {
-        return OffsetDateTime.parse(requireText(record, columnName));
+        try {
+            return OffsetDateTime.parse(requireText(record, columnName));
+        } catch (DateTimeParseException exception) {
+            throw invalidValue(record, columnName + " 값은 ISO-8601 OffsetDateTime 형식이어야 합니다.");
+        }
+    }
+
+    private IllegalArgumentException invalidValue(CSVRecord record, String message) {
+        return new IllegalArgumentException("행 " + record.getRecordNumber() + ": " + message);
+    }
+
+    private int calculateFailedRowCount(int totalRowCount, int successRowCount) {
+        return totalRowCount > successRowCount ? 1 : 0;
     }
 }

--- a/src/main/java/com/sellerinsight/importjob/application/OrderCsvImportService.java
+++ b/src/main/java/com/sellerinsight/importjob/application/OrderCsvImportService.java
@@ -20,12 +20,11 @@ public class OrderCsvImportService {
     private final SellerRepository sellerRepository;
     private final ImportJobRepository importJobRepository;
     private final OrderCsvImportProcessor orderCsvImportProcessor;
+    private final CsvFileValidator csvFileValidator;
     private final TransactionTemplate transactionTemplate;
 
     public ImportJobResponse importCsv(Long sellerId, MultipartFile file) {
-        if (file == null || file.isEmpty()) {
-            throw new BusinessException(ErrorCode.CSV_IMPORT_INVALID_FILE);
-        }
+        csvFileValidator.validate(file);
 
         Seller seller = sellerRepository.findById(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
@@ -48,6 +47,17 @@ public class OrderCsvImportService {
             transactionTemplate.executeWithoutResult(status ->
                     orderCsvImportProcessor.process(sellerId, importJob.getId(), file)
             );
+        } catch (CsvImportProcessingException exception) {
+            transactionTemplate.executeWithoutResult(status -> {
+                ImportJob failedJob = importJobRepository.findByIdAndSellerId(importJob.getId(), sellerId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.IMPORT_JOB_NOT_FOUND));
+                failedJob.markFailed(
+                        exception.getTotalRowCount(),
+                        exception.getSuccessRowCount(),
+                        exception.getFailedRowCount(),
+                        exception.getMessage()
+                );
+            });
         } catch (Exception exception) {
             transactionTemplate.executeWithoutResult(status -> {
                 ImportJob failedJob = importJobRepository.findByIdAndSellerId(importJob.getId(), sellerId)

--- a/src/main/java/com/sellerinsight/importjob/config/CsvImportConfig.java
+++ b/src/main/java/com/sellerinsight/importjob/config/CsvImportConfig.java
@@ -1,0 +1,9 @@
+package com.sellerinsight.importjob.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(CsvImportProperties.class)
+public class CsvImportConfig {
+}

--- a/src/main/java/com/sellerinsight/importjob/config/CsvImportProperties.java
+++ b/src/main/java/com/sellerinsight/importjob/config/CsvImportProperties.java
@@ -1,0 +1,16 @@
+package com.sellerinsight.importjob.config;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.unit.DataSize;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "app.import.csv")
+public record CsvImportProperties(
+        @NotNull DataSize maxFileSize,
+        @NotEmpty List<String> allowedContentTypes
+) {
+}

--- a/src/main/java/com/sellerinsight/importjob/domain/ImportJob.java
+++ b/src/main/java/com/sellerinsight/importjob/domain/ImportJob.java
@@ -89,7 +89,19 @@ public class ImportJob extends BaseEntity {
     }
 
     public void markFailed(String errorMessage) {
+        markFailed(this.totalRowCount, this.successRowCount, this.failedRowCount, errorMessage);
+    }
+
+    public void markFailed(
+            int totalRowCount,
+            int successRowCount,
+            int failedRowCount,
+            String errorMessage
+    ) {
         this.status = ImportJobStatus.FAILED;
+        this.totalRowCount = totalRowCount;
+        this.successRowCount = successRowCount;
+        this.failedRowCount = failedRowCount;
         this.endedAt = OffsetDateTime.now(ASIA_SEOUL);
         this.errorMessage = truncate(errorMessage);
     }

--- a/src/main/java/com/sellerinsight/product/domain/Product.java
+++ b/src/main/java/com/sellerinsight/product/domain/Product.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 
 @Getter
 @Entity
@@ -46,13 +47,17 @@ public class Product extends BaseEntity {
     @Column(name = "product_status", nullable = false, length = 50)
     private String productStatus;
 
+    @Column(name = "last_imported_at", nullable = false)
+    private OffsetDateTime lastImportedAt;
+
     private Product(
             Seller seller,
             String externalProductId,
             String productName,
             BigDecimal salePrice,
             Integer stockQuantity,
-            String productStatus
+            String productStatus,
+            OffsetDateTime lastImportedAt
     ) {
         this.seller = seller;
         this.externalProductId = externalProductId;
@@ -60,6 +65,7 @@ public class Product extends BaseEntity {
         this.salePrice = salePrice;
         this.stockQuantity = stockQuantity;
         this.productStatus = productStatus;
+        this.lastImportedAt = lastImportedAt;
     }
 
     public static Product create(
@@ -68,7 +74,8 @@ public class Product extends BaseEntity {
             String productName,
             BigDecimal salePrice,
             Integer stockQuantity,
-            String productStatus
+            String productStatus,
+            OffsetDateTime lastImportedAt
     ) {
         return new Product(
                 seller,
@@ -76,20 +83,26 @@ public class Product extends BaseEntity {
                 productName,
                 salePrice,
                 stockQuantity,
-                productStatus
+                productStatus,
+                lastImportedAt
         );
     }
 
     public void updateFromImport(
+            OffsetDateTime importedAt,
             String productName,
             BigDecimal salePrice,
             Integer stockQuantity,
             String productStatus
     ) {
+        if (importedAt.isBefore(this.lastImportedAt)) {
+            return;
+        }
+
         this.productName = productName;
         this.salePrice = salePrice;
         this.stockQuantity = stockQuantity;
         this.productStatus = productStatus;
+        this.lastImportedAt = importedAt;
     }
 }
-

--- a/src/main/java/com/sellerinsight/sampledata/application/SampleDataBootstrapService.java
+++ b/src/main/java/com/sellerinsight/sampledata/application/SampleDataBootstrapService.java
@@ -135,7 +135,8 @@ public class SampleDataBootstrapService {
                         "Alpha 베스트셀러",
                         new BigDecimal("15000"),
                         12,
-                        "ON_SALE"
+                        "ON_SALE",
+                        importedAt(previousMetricDate)
                 )
         );
         Product soldOutProduct = productRepository.saveAndFlush(
@@ -145,7 +146,8 @@ public class SampleDataBootstrapService {
                         "Alpha 품절 상품",
                         new BigDecimal("23000"),
                         0,
-                        "SOLD_OUT"
+                        "SOLD_OUT",
+                        importedAt(previousMetricDate)
                 )
         );
         Product staleProduct = productRepository.saveAndFlush(
@@ -155,7 +157,8 @@ public class SampleDataBootstrapService {
                         "Alpha 장기 미판매 상품",
                         new BigDecimal("18000"),
                         7,
-                        "ON_SALE"
+                        "ON_SALE",
+                        importedAt(staleMetricDate)
                 )
         );
 
@@ -247,7 +250,8 @@ public class SampleDataBootstrapService {
                         "Beta 대표 상품",
                         new BigDecimal("12000"),
                         14,
-                        "ON_SALE"
+                        "ON_SALE",
+                        importedAt(previousMetricDate)
                 )
         );
         Product secondaryProduct = productRepository.saveAndFlush(
@@ -257,7 +261,8 @@ public class SampleDataBootstrapService {
                         "Beta 보조 상품",
                         new BigDecimal("9000"),
                         20,
-                        "ON_SALE"
+                        "ON_SALE",
+                        importedAt(previousMetricDate)
                 )
         );
 
@@ -361,6 +366,10 @@ public class SampleDataBootstrapService {
                         itemAmount
                 )
         );
+    }
+
+    private OffsetDateTime importedAt(LocalDate metricDate) {
+        return metricDate.atStartOfDay(ASIA_SEOUL).toOffsetDateTime();
     }
 
     private record SellerSeedResult(

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -27,6 +27,13 @@ app:
     daily:
       enabled: false
       lock-timeout-minutes: 30
+  import:
+    csv:
+      max-file-size: 5MB
+      allowed-content-types:
+        - text/csv
+        - application/csv
+        - application/vnd.ms-excel
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
     default: local
   lifecycle:
     timeout-per-shutdown-phase: 20s
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
   jpa:
     open-in-view: false
     hibernate:
@@ -69,6 +73,13 @@ app:
       enabled: true
       cron: 0 5 2 * * *
       lock-timeout-minutes: 30
+  import:
+    csv:
+      max-file-size: 5MB
+      allowed-content-types:
+        - text/csv
+        - application/csv
+        - application/vnd.ms-excel
 
 logging:
   level:

--- a/src/main/resources/db/migration/V10__add_last_imported_at_to_products.sql
+++ b/src/main/resources/db/migration/V10__add_last_imported_at_to_products.sql
@@ -1,0 +1,9 @@
+alter table products
+    add column last_imported_at timestamp with time zone;
+
+update products
+set last_imported_at = updated_at
+where last_imported_at is null;
+
+alter table products
+    alter column last_imported_at set not null;

--- a/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
+++ b/src/test/java/com/sellerinsight/importjob/api/ImportJobControllerTest.java
@@ -15,11 +15,13 @@ import com.sellerinsight.order.domain.CustomerOrderRepository;
 import com.sellerinsight.order.domain.OrderItemRepository;
 import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
 import com.sellerinsight.pipeline.domain.PipelineRunRepository;
+import com.sellerinsight.product.domain.Product;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.domain.Seller;
 import com.sellerinsight.seller.domain.SellerCredentialRepository;
 import com.sellerinsight.seller.domain.SellerRepository;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -164,5 +166,173 @@ class ImportJobControllerTest {
         assertThat(customerOrderRepository.count()).isZero();
         assertThat(orderItemRepository.count()).isZero();
         assertThat(importJobRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void importOrdersCsvRejectsInvalidExtension() throws Exception {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("seller-001", "sellerinsight-store")
+        );
+
+        String csv = """
+                orderNo,orderItemNo,orderedAt,orderStatus,productId,productName,quantity,unitPrice,itemAmount,totalAmount,salePrice,stockQuantity,productStatus
+                ORD-001,ITEM-001,2026-04-16T10:00:00+09:00,PAID,PROD-001,테스트 상품,2,15000,30000,30000,15000,10,ON_SALE
+                """;
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "orders.txt",
+                "text/csv",
+                csv.getBytes(StandardCharsets.UTF_8)
+        );
+
+        mockMvc.perform(
+                        multipart("/api/v1/sellers/{sellerId}/import-jobs/orders/csv", seller.getId())
+                                .file(file)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("IMPORT_400_3"));
+
+        assertThat(importJobRepository.count()).isZero();
+    }
+
+    @Test
+    void importOrdersCsvRejectsUnsupportedContentType() throws Exception {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("seller-001", "sellerinsight-store")
+        );
+
+        String csv = """
+                orderNo,orderItemNo,orderedAt,orderStatus,productId,productName,quantity,unitPrice,itemAmount,totalAmount,salePrice,stockQuantity,productStatus
+                ORD-001,ITEM-001,2026-04-16T10:00:00+09:00,PAID,PROD-001,테스트 상품,2,15000,30000,30000,15000,10,ON_SALE
+                """;
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "orders.csv",
+                "application/json",
+                csv.getBytes(StandardCharsets.UTF_8)
+        );
+
+        mockMvc.perform(
+                        multipart("/api/v1/sellers/{sellerId}/import-jobs/orders/csv", seller.getId())
+                                .file(file)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("IMPORT_400_3"));
+
+        assertThat(importJobRepository.count()).isZero();
+    }
+
+    @Test
+    void importOrdersCsvRejectsTooLargeFile() throws Exception {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("seller-001", "sellerinsight-store")
+        );
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "orders.csv",
+                "text/csv",
+                new byte[5 * 1024 * 1024 + 1]
+        );
+
+        mockMvc.perform(
+                        multipart("/api/v1/sellers/{sellerId}/import-jobs/orders/csv", seller.getId())
+                                .file(file)
+                )
+                .andExpect(status().isPayloadTooLarge())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("IMPORT_413_1"));
+
+        assertThat(importJobRepository.count()).isZero();
+    }
+
+    @Test
+    void importOrdersCsvMarksFailedWhenQuantityIsNegative() throws Exception {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("seller-001", "sellerinsight-store")
+        );
+
+        String csv = """
+                orderNo,orderItemNo,orderedAt,orderStatus,productId,productName,quantity,unitPrice,itemAmount,totalAmount,salePrice,stockQuantity,productStatus
+                ORD-001,ITEM-001,2026-04-16T10:00:00+09:00,PAID,PROD-001,테스트 상품,-1,15000,30000,30000,15000,10,ON_SALE
+                """;
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "orders.csv",
+                "text/csv",
+                csv.getBytes(StandardCharsets.UTF_8)
+        );
+
+        mockMvc.perform(
+                        multipart("/api/v1/sellers/{sellerId}/import-jobs/orders/csv", seller.getId())
+                                .file(file)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("FAILED"))
+                .andExpect(jsonPath("$.data.totalRowCount").value(1))
+                .andExpect(jsonPath("$.data.successRowCount").value(0))
+                .andExpect(jsonPath("$.data.failedRowCount").value(1))
+                .andExpect(jsonPath("$.data.errorMessage").value("행 1: quantity 값은 0보다 커야 합니다."));
+    }
+
+    @Test
+    void importOrdersCsvKeepsLatestProductStateWhenOlderCsvIsReuploaded() throws Exception {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("seller-001", "sellerinsight-store")
+        );
+
+        String latestCsv = """
+                orderNo,orderItemNo,orderedAt,orderStatus,productId,productName,quantity,unitPrice,itemAmount,totalAmount,salePrice,stockQuantity,productStatus
+                ORD-NEW-001,ITEM-NEW-001,2026-04-20T10:00:00+09:00,PAID,PROD-001,최신 상품명,1,15000,15000,15000,15000,10,ON_SALE
+                """;
+
+        String oldCsv = """
+                orderNo,orderItemNo,orderedAt,orderStatus,productId,productName,quantity,unitPrice,itemAmount,totalAmount,salePrice,stockQuantity,productStatus
+                ORD-OLD-001,ITEM-OLD-001,2026-04-19T10:00:00+09:00,PAID,PROD-001,과거 상품명,1,15000,15000,15000,15000,0,SOLD_OUT
+                """;
+
+        MockMultipartFile latestFile = new MockMultipartFile(
+                "file",
+                "latest-orders.csv",
+                "text/csv",
+                latestCsv.getBytes(StandardCharsets.UTF_8)
+        );
+
+        MockMultipartFile oldFile = new MockMultipartFile(
+                "file",
+                "old-orders.csv",
+                "text/csv",
+                oldCsv.getBytes(StandardCharsets.UTF_8)
+        );
+
+        mockMvc.perform(
+                        multipart("/api/v1/sellers/{sellerId}/import-jobs/orders/csv", seller.getId())
+                                .file(latestFile)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+
+        mockMvc.perform(
+                        multipart("/api/v1/sellers/{sellerId}/import-jobs/orders/csv", seller.getId())
+                                .file(oldFile)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+
+        Product product = productRepository.findBySellerIdAndExternalProductId(seller.getId(), "PROD-001")
+                .orElseThrow();
+
+        assertThat(product.getProductName()).isEqualTo("최신 상품명");
+        assertThat(product.getStockQuantity()).isEqualTo(10);
+        assertThat(product.getProductStatus()).isEqualTo("ON_SALE");
+        assertThat(product.getSalePrice()).isEqualByComparingTo("15000");
+        assertThat(product.getLastImportedAt())
+                .isEqualTo(OffsetDateTime.parse("2026-04-20T10:00:00+09:00"));
     }
 }

--- a/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
+++ b/src/test/java/com/sellerinsight/metric/api/DailyMetricControllerTest.java
@@ -100,7 +100,8 @@ class DailyMetricControllerTest {
                         "품절 상품",
                         new BigDecimal("30000"),
                         0,
-                        "SOLD_OUT"
+                        "SOLD_OUT",
+                        OffsetDateTime.parse("2026-04-16T00:00:00+09:00")
                 )
         );
 
@@ -111,7 +112,8 @@ class DailyMetricControllerTest {
                         "판매중 상품",
                         new BigDecimal("15000"),
                         12,
-                        "ON_SALE"
+                        "ON_SALE",
+                        OffsetDateTime.parse("2026-04-16T00:00:00+09:00")
                 )
         );
 
@@ -122,7 +124,8 @@ class DailyMetricControllerTest {
                         "장기 미판매 상품",
                         new BigDecimal("20000"),
                         7,
-                        "ON_SALE"
+                        "ON_SALE",
+                        OffsetDateTime.parse("2026-03-20T00:00:00+09:00")
                 )
         );
 


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [x] FEAT
- [ ] TASK

## 작업 요약
주문 CSV 업로드 경로에 파일 정책 검증과 행 단위 값 검증을 추가해 입력 안정성을 강화했습니다.
또한 상품에 `last_imported_at`을 도입해 오래된 CSV가 최신 상품 상태와 재고를 덮어쓰지 않도록 보호 로직을 추가했습니다.

## 주요 변경점
- `app.import.csv` 설정 추가
- `CsvImportProperties`, `CsvImportConfig`, `CsvFileValidator` 추가
- 파일 확장자, content-type, 최대 크기 검증 추가
- `CSV_IMPORT_INVALID_FILE_TYPE`, `CSV_IMPORT_FILE_TOO_LARGE` 에러 코드 추가
- `GlobalExceptionHandler`에 업로드 크기 초과 예외 처리 추가
- `CsvImportProcessingException` 추가
- `OrderCsvImportService`, `OrderCsvImportProcessor`에 row 단위 실패 카운트 및 상세 메시지 반영
- 필수값, 숫자 형식, 날짜 형식, 음수 값 검증 강화
- `products.last_imported_at` 컬럼 및 최신성 보호 로직 추가
- 오래된 CSV 재업로드 시 상품 상태 역행 방지
- `ImportJobControllerTest`에 파일 정책/값 검증/최신성 보호 테스트 추가
- `SampleDataBootstrapService`, `DailyMetricControllerTest` 등 `Product.create(...)` 호출부 시그니처 정리

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #25 