### PR TITLE
[FEAT] 인사이트 규칙 엔진 확장

### DIFF
--- a/src/main/java/com/sellerinsight/insight/application/AverageOrderAmountDropRule.java
+++ b/src/main/java/com/sellerinsight/insight/application/AverageOrderAmountDropRule.java
@@ -1,0 +1,75 @@
+package com.sellerinsight.insight.application;
+
+import com.sellerinsight.insight.domain.InsightSeverity;
+import com.sellerinsight.insight.domain.InsightType;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(5)
+public class AverageOrderAmountDropRule implements InsightRule {
+
+    @Override
+    public Optional<InsightCandidate> evaluate(MetricContext context) {
+        if (context.previousMetric() == null) {
+            return Optional.empty();
+        }
+
+        BigDecimal previousAverageOrderAmount = context.previousMetric().getAverageOrderAmount();
+        BigDecimal currentAverageOrderAmount = context.currentMetric().getAverageOrderAmount();
+
+        if (previousAverageOrderAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            return Optional.empty();
+        }
+
+        double changeRate = currentAverageOrderAmount
+                .subtract(previousAverageOrderAmount)
+                .divide(previousAverageOrderAmount, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .doubleValue();
+
+        if (changeRate > -20.0) {
+            return Optional.empty();
+        }
+
+        InsightSeverity severity = changeRate <= -35.0
+                ? InsightSeverity.HIGH
+                : InsightSeverity.MEDIUM;
+
+        return Optional.of(new InsightCandidate(
+                InsightType.AVERAGE_ORDER_AMOUNT_DROP,
+                severity,
+                "평균 주문 금액이 감소했습니다.",
+                "전일 평균 주문 금액 "
+                        + previousAverageOrderAmount
+                        + "원에서 대상일 "
+                        + currentAverageOrderAmount
+                        + "원으로 감소했습니다.",
+                Map.of(
+                        "previousAverageOrderAmount", previousAverageOrderAmount,
+                        "currentAverageOrderAmount", currentAverageOrderAmount,
+                        "changeRate", changeRate
+                ),
+                List.of(
+                        new RecommendationCandidate(
+                                1,
+                                "CHECK_LOW_PRICE_ORDERS",
+                                "저가 상품 주문 비중을 확인하세요.",
+                                "평균 주문 금액 하락이 특정 저가 상품 또는 할인 상품 집중 때문인지 확인하세요."
+                        ),
+                        new RecommendationCandidate(
+                                2,
+                                "REVIEW_BUNDLE_STRATEGY",
+                                "묶음 구매 전략을 검토하세요.",
+                                "객단가 회복을 위해 세트 구성, 무료배송 기준, 추가 구매 유도 상품을 점검하세요."
+                        )
+                ),
+                "AverageOrderAmountDropRule"
+        ));
+    }
+}

--- a/src/main/java/com/sellerinsight/insight/application/NoOrderRule.java
+++ b/src/main/java/com/sellerinsight/insight/application/NoOrderRule.java
@@ -1,0 +1,57 @@
+package com.sellerinsight.insight.application;
+
+import com.sellerinsight.insight.domain.InsightSeverity;
+import com.sellerinsight.insight.domain.InsightType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(3)
+public class NoOrderRule implements InsightRule {
+
+    @Override
+    public Optional<InsightCandidate> evaluate(MetricContext context) {
+        int currentOrderCount = context.currentMetric().getOrderCount();
+
+        if (currentOrderCount > 0) {
+            return Optional.empty();
+        }
+
+        Integer previousOrderCount = context.previousMetric() == null
+                ? null
+                : context.previousMetric().getOrderCount();
+
+        InsightSeverity severity = previousOrderCount != null && previousOrderCount >= 3
+                ? InsightSeverity.HIGH
+                : InsightSeverity.MEDIUM;
+
+        return Optional.of(new InsightCandidate(
+                InsightType.NO_ORDER,
+                severity,
+                "오늘 주문이 발생하지 않았습니다.",
+                "대상일에 주문이 0건으로 확인되었습니다. 노출, 가격, 재고, 판매 상태를 우선 점검해야 합니다.",
+                Map.of(
+                        "currentOrderCount", currentOrderCount,
+                        "previousOrderCount", previousOrderCount == null ? "N/A" : previousOrderCount
+                ),
+                List.of(
+                        new RecommendationCandidate(
+                                1,
+                                "CHECK_PRODUCT_VISIBILITY",
+                                "상품 노출 상태를 확인하세요.",
+                                "주요 상품이 검색과 카테고리에서 정상 노출되는지 먼저 확인하세요."
+                        ),
+                        new RecommendationCandidate(
+                                2,
+                                "CHECK_PURCHASE_BLOCKERS",
+                                "구매 방해 요인을 점검하세요.",
+                                "품절, 배송 정책, 가격 변경, 판매중지 상태 등 주문을 막는 요인이 있는지 확인하세요."
+                        )
+                ),
+                "NoOrderRule"
+        ));
+    }
+}

--- a/src/main/java/com/sellerinsight/insight/application/StaleProductRiskRule.java
+++ b/src/main/java/com/sellerinsight/insight/application/StaleProductRiskRule.java
@@ -1,0 +1,52 @@
+package com.sellerinsight.insight.application;
+
+import com.sellerinsight.insight.domain.InsightSeverity;
+import com.sellerinsight.insight.domain.InsightType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(4)
+public class StaleProductRiskRule implements InsightRule {
+
+    @Override
+    public Optional<InsightCandidate> evaluate(MetricContext context) {
+        int staleProductCount = context.currentMetric().getStaleProductCount();
+
+        if (staleProductCount <= 0) {
+            return Optional.empty();
+        }
+
+        InsightSeverity severity = staleProductCount >= 5
+                ? InsightSeverity.HIGH
+                : InsightSeverity.MEDIUM;
+
+        return Optional.of(new InsightCandidate(
+                InsightType.STALE_PRODUCT_RISK,
+                severity,
+                "장기 미판매 상품이 증가하고 있습니다.",
+                "최근 판매 이력이 없는 상품이 " + staleProductCount + "개 확인되었습니다.",
+                Map.of(
+                        "staleProductCount", staleProductCount
+                ),
+                List.of(
+                        new RecommendationCandidate(
+                                1,
+                                "REVIEW_STALE_PRODUCTS",
+                                "장기 미판매 상품을 재점검하세요.",
+                                "최근 판매가 없는 상품의 가격, 대표 이미지, 상세페이지, 키워드를 우선 점검하세요."
+                        ),
+                        new RecommendationCandidate(
+                                2,
+                                "PROMOTION_OR_DELIST",
+                                "프로모션 또는 정리를 검토하세요.",
+                                "회전율이 낮은 상품은 할인, 묶음 구성, 노출 축소 또는 판매 종료를 검토하세요."
+                        )
+                ),
+                "StaleProductRiskRule"
+        ));
+    }
+}

--- a/src/main/java/com/sellerinsight/insight/domain/InsightType.java
+++ b/src/main/java/com/sellerinsight/insight/domain/InsightType.java
@@ -2,5 +2,8 @@ package com.sellerinsight.insight.domain;
 
 public enum InsightType {
     ORDER_DROP,
-    SOLD_OUT_RISK
+    SOLD_OUT_RISK,
+    NO_ORDER,
+    STALE_PRODUCT_RISK,
+    AVERAGE_ORDER_AMOUNT_DROP
 }

--- a/src/test/java/com/sellerinsight/insight/api/InsightControllerTest.java
+++ b/src/test/java/com/sellerinsight/insight/api/InsightControllerTest.java
@@ -18,6 +18,8 @@ import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.domain.Seller;
 import com.sellerinsight.seller.domain.SellerCredentialRepository;
 import com.sellerinsight.seller.domain.SellerRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,9 +27,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
@@ -108,8 +107,8 @@ class InsightControllerTest {
                         seller,
                         LocalDate.of(2026, 4, 16),
                         5,
-                        new BigDecimal("50000"),
-                        new BigDecimal("10000"),
+                        new BigDecimal("30000"),
+                        new BigDecimal("6000"),
                         2,
                         1
                 )
@@ -122,11 +121,13 @@ class InsightControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.metricDate").value("2026-04-16"))
-                .andExpect(jsonPath("$.data.insightCount").value(2))
+                .andExpect(jsonPath("$.data.insightCount").value(4))
                 .andExpect(jsonPath("$.data.insights[0].insightType").value("ORDER_DROP"))
                 .andExpect(jsonPath("$.data.insights[1].insightType").value("SOLD_OUT_RISK"))
+                .andExpect(jsonPath("$.data.insights[2].insightType").value("STALE_PRODUCT_RISK"))
+                .andExpect(jsonPath("$.data.insights[3].insightType").value("AVERAGE_ORDER_AMOUNT_DROP"))
                 .andExpect(jsonPath("$.data.insights[0].recommendations[0].priority").value(1))
-                .andExpect(jsonPath("$.data.insights[1].recommendations[0].priority").value(1));
+                .andExpect(jsonPath("$.data.insights[3].recommendations[0].priority").value(1));
 
         Long insightId = insightRepository.findAll().get(0).getId();
 
@@ -136,7 +137,7 @@ class InsightControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.insightCount").value(2));
+                .andExpect(jsonPath("$.data.insightCount").value(4));
 
         mockMvc.perform(
                         get("/api/v1/sellers/{sellerId}/insights/{insightId}", seller.getId(), insightId)
@@ -144,5 +145,48 @@ class InsightControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(insightId));
+    }
+
+    @Test
+    void generateNoOrderInsight() throws Exception {
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create("seller-002", "no-order-store")
+        );
+
+        dailyMetricRepository.saveAndFlush(
+                DailyMetric.create(
+                        seller,
+                        LocalDate.of(2026, 4, 15),
+                        4,
+                        new BigDecimal("80000"),
+                        new BigDecimal("20000"),
+                        0,
+                        0
+                )
+        );
+
+        dailyMetricRepository.saveAndFlush(
+                DailyMetric.create(
+                        seller,
+                        LocalDate.of(2026, 4, 16),
+                        0,
+                        BigDecimal.ZERO.setScale(2),
+                        BigDecimal.ZERO.setScale(2),
+                        0,
+                        0
+                )
+        );
+
+        mockMvc.perform(
+                        post("/api/v1/sellers/{sellerId}/insights/generate", seller.getId())
+                                .param("date", "2026-04-16")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.metricDate").value("2026-04-16"))
+                .andExpect(jsonPath("$.data.insightCount").value(3))
+                .andExpect(jsonPath("$.data.insights[0].insightType").value("ORDER_DROP"))
+                .andExpect(jsonPath("$.data.insights[1].insightType").value("NO_ORDER"))
+                .andExpect(jsonPath("$.data.insights[2].insightType").value("AVERAGE_ORDER_AMOUNT_DROP"));
     }
 }

--- a/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
+++ b/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
@@ -125,7 +125,7 @@ class AdminSampleDataControllerTest {
                 .andExpect(jsonPath("$.data.totalSellerCount").value(2))
                 .andExpect(jsonPath("$.data.processedSellerCount").value(2))
                 .andExpect(jsonPath("$.data.failedSellerCount").value(0))
-                .andExpect(jsonPath("$.data.generatedInsightCount").value(2))
+                .andExpect(jsonPath("$.data.generatedInsightCount").value(3))
                 .andExpect(jsonPath("$.data.status").value("SUCCESS"));
 
         Seller alphaSeller = sellerRepository.findAll().stream()
@@ -145,7 +145,7 @@ class AdminSampleDataControllerTest {
                 .andExpect(jsonPath("$.data.latestMetric.orderCount").value(2))
                 .andExpect(jsonPath("$.data.latestMetric.soldOutProductCount").value(1))
                 .andExpect(jsonPath("$.data.latestMetric.staleProductCount").value(1))
-                .andExpect(jsonPath("$.data.insightSummary.totalCount").value(3))
+                .andExpect(jsonPath("$.data.insightSummary.totalCount").value(5))
                 .andExpect(jsonPath("$.data.latestPipelineStatus.status").value("SUCCESS"));
 
         mockMvc.perform(
@@ -154,7 +154,7 @@ class AdminSampleDataControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.insightCount").value(3));
+                .andExpect(jsonPath("$.data.insightCount").value(5));
 
         mockMvc.perform(
                         get("/api/v1/admin/pipelines/daily/runs")


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [x] FEAT
- [ ] TASK

## 작업 요약
인사이트 규칙 엔진에 주문 0건, 장기 미판매 상품, 평균 주문 금액 하락 감지 규칙을 추가했습니다.

## 주요 변경점
- InsightType에 NO_ORDER, STALE_PRODUCT_RISK, AVERAGE_ORDER_AMOUNT_DROP 추가
- NoOrderRule, StaleProductRiskRule, AverageOrderAmountDropRule 구현
- 신규 규칙 생성 순서와 추천 액션 생성 로직 검증 테스트 추가
- 샘플 데이터 전체 사이클 테스트의 인사이트 생성 개수 갱신

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #27 