### PR TITLE
[TEST] 파이프라인 BEFORE 성능 측정 기반 추가

### DIFF
--- a/src/main/java/com/sellerinsight/pipeline/api/dto/DailyPipelineRunResponse.java
+++ b/src/main/java/com/sellerinsight/pipeline/api/dto/DailyPipelineRunResponse.java
@@ -21,7 +21,8 @@ public record DailyPipelineRunResponse(
         int generatedInsightCount,
         List<Long> failedSellerIds,
         OffsetDateTime startedAt,
-        OffsetDateTime endedAt
+        OffsetDateTime endedAt,
+        Long durationMs
 ) {
     public static DailyPipelineRunResponse from(
             PipelineRun pipelineRun,
@@ -39,7 +40,8 @@ public record DailyPipelineRunResponse(
                 pipelineRun.getGeneratedInsightCount(),
                 failedSellerIds,
                 pipelineRun.getStartedAt(),
-                pipelineRun.getEndedAt()
+                pipelineRun.getEndedAt(),
+                pipelineRun.getDurationMs()
         );
     }
 }

--- a/src/main/java/com/sellerinsight/pipeline/api/dto/PipelineRunItemResponse.java
+++ b/src/main/java/com/sellerinsight/pipeline/api/dto/PipelineRunItemResponse.java
@@ -12,7 +12,8 @@ public record PipelineRunItemResponse(
         int generatedInsightCount,
         String errorMessage,
         OffsetDateTime startedAt,
-        OffsetDateTime endedAt
+        OffsetDateTime endedAt,
+        Long durationMs
 ) {
     public static PipelineRunItemResponse from(PipelineRunItem pipelineRunItem) {
         return new PipelineRunItemResponse(
@@ -22,7 +23,8 @@ public record PipelineRunItemResponse(
                 pipelineRunItem.getGeneratedInsightCount(),
                 pipelineRunItem.getErrorMessage(),
                 pipelineRunItem.getStartedAt(),
-                pipelineRunItem.getEndedAt()
+                pipelineRunItem.getEndedAt(),
+                pipelineRunItem.getDurationMs()
         );
     }
 }

--- a/src/main/java/com/sellerinsight/pipeline/api/dto/PipelineRunSummaryResponse.java
+++ b/src/main/java/com/sellerinsight/pipeline/api/dto/PipelineRunSummaryResponse.java
@@ -19,7 +19,8 @@ public record PipelineRunSummaryResponse(
         int failedSellerCount,
         int generatedInsightCount,
         OffsetDateTime startedAt,
-        OffsetDateTime endedAt
+        OffsetDateTime endedAt,
+        Long durationMs
 ) {
     public static PipelineRunSummaryResponse from(PipelineRun pipelineRun) {
         return new PipelineRunSummaryResponse(
@@ -33,7 +34,8 @@ public record PipelineRunSummaryResponse(
                 pipelineRun.getFailedSellerCount(),
                 pipelineRun.getGeneratedInsightCount(),
                 pipelineRun.getStartedAt(),
-                pipelineRun.getEndedAt()
+                pipelineRun.getEndedAt(),
+                pipelineRun.getDurationMs()
         );
     }
 }

--- a/src/main/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionService.java
+++ b/src/main/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionService.java
@@ -101,6 +101,8 @@ public class DailyPipelineExecutionService {
             List<Long> failedSellerIds = new ArrayList<>();
 
             for (Seller seller : sellers) {
+                OffsetDateTime itemStartedAt = OffsetDateTime.now(ASIA_SEOUL);
+
                 try {
                     dailyMetricAggregationService.aggregate(seller.getId(), metricDate);
                     InsightsByDateResponse insightResult = insightGenerationService.generate(
@@ -111,22 +113,30 @@ public class DailyPipelineExecutionService {
                     processedSellerCount++;
                     generatedInsightCount += insightResult.insightCount();
 
+                    OffsetDateTime itemEndedAt = OffsetDateTime.now(ASIA_SEOUL);
+
                     pipelineRunItemRepository.save(
                             PipelineRunItem.success(
                                     pipelineRun,
                                     seller,
-                                    insightResult.insightCount()
+                                    insightResult.insightCount(),
+                                    itemStartedAt,
+                                    itemEndedAt
                             )
                     );
                 } catch (Exception exception) {
                     failedSellerCount++;
                     failedSellerIds.add(seller.getId());
 
+                    OffsetDateTime itemEndedAt = OffsetDateTime.now(ASIA_SEOUL);
+
                     pipelineRunItemRepository.save(
                             PipelineRunItem.failed(
                                     pipelineRun,
                                     seller,
-                                    resolveErrorMessage(exception)
+                                    resolveErrorMessage(exception),
+                                    itemStartedAt,
+                                    itemEndedAt
                             )
                     );
 

--- a/src/main/java/com/sellerinsight/pipeline/domain/PipelineRun.java
+++ b/src/main/java/com/sellerinsight/pipeline/domain/PipelineRun.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -88,5 +89,13 @@ public class PipelineRun extends BaseEntity {
         this.failedSellerCount = failedSellerCount;
         this.generatedInsightCount = generatedInsightCount;
         this.endedAt = OffsetDateTime.now(ASIA_SEOUL);
+    }
+
+    public Long getDurationMs() {
+        if (startedAt == null || endedAt == null) {
+            return null;
+        }
+
+        return Duration.between(startedAt, endedAt).toMillis();
     }
 }

--- a/src/main/java/com/sellerinsight/pipeline/domain/PipelineRunItem.java
+++ b/src/main/java/com/sellerinsight/pipeline/domain/PipelineRunItem.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 
@@ -55,17 +56,17 @@ public class PipelineRunItem extends BaseEntity {
             Seller seller,
             PipelineRunItemStatus status,
             int generatedInsightCount,
-            String errorMessage
+            String errorMessage,
+            OffsetDateTime startedAt,
+            OffsetDateTime endedAt
     ) {
-        OffsetDateTime now = OffsetDateTime.now(ASIA_SEOUL);
-
         this.pipelineRun = pipelineRun;
         this.seller = seller;
         this.status = status;
         this.generatedInsightCount = generatedInsightCount;
         this.errorMessage = truncate(errorMessage);
-        this.startedAt = now;
-        this.endedAt = now;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
     }
 
     public static PipelineRunItem success(
@@ -73,12 +74,32 @@ public class PipelineRunItem extends BaseEntity {
             Seller seller,
             int generatedInsightCount
     ) {
+        OffsetDateTime now = OffsetDateTime.now(ASIA_SEOUL);
+
+        return success(
+                pipelineRun,
+                seller,
+                generatedInsightCount,
+                now,
+                now
+        );
+    }
+
+    public static PipelineRunItem success(
+            PipelineRun pipelineRun,
+            Seller seller,
+            int generatedInsightCount,
+            OffsetDateTime startedAt,
+            OffsetDateTime endedAt
+    ) {
         return new PipelineRunItem(
                 pipelineRun,
                 seller,
                 PipelineRunItemStatus.SUCCESS,
                 generatedInsightCount,
-                null
+                null,
+                startedAt,
+                endedAt
         );
     }
 
@@ -87,13 +108,41 @@ public class PipelineRunItem extends BaseEntity {
             Seller seller,
             String errorMessage
     ) {
+        OffsetDateTime now = OffsetDateTime.now(ASIA_SEOUL);
+
+        return failed(
+                pipelineRun,
+                seller,
+                errorMessage,
+                now,
+                now
+        );
+    }
+
+    public static PipelineRunItem failed(
+            PipelineRun pipelineRun,
+            Seller seller,
+            String errorMessage,
+            OffsetDateTime startedAt,
+            OffsetDateTime endedAt
+    ) {
         return new PipelineRunItem(
                 pipelineRun,
                 seller,
                 PipelineRunItemStatus.FAILED,
                 0,
-                errorMessage
+                errorMessage,
+                startedAt,
+                endedAt
         );
+    }
+
+    public Long getDurationMs() {
+        if (startedAt == null || endedAt == null) {
+            return null;
+        }
+
+        return Duration.between(startedAt, endedAt).toMillis();
     }
 
     private static String truncate(String message) {

--- a/src/main/java/com/sellerinsight/sampledata/application/SampleDataBootstrapService.java
+++ b/src/main/java/com/sellerinsight/sampledata/application/SampleDataBootstrapService.java
@@ -12,6 +12,7 @@ import com.sellerinsight.order.domain.OrderItem;
 import com.sellerinsight.order.domain.OrderItemRepository;
 import com.sellerinsight.pipeline.domain.PipelineRunItemRepository;
 import com.sellerinsight.pipeline.domain.PipelineRunRepository;
+import com.sellerinsight.pipeline.domain.PipelineExecutionLockRepository;
 import com.sellerinsight.product.domain.Product;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.sampledata.api.dto.SampleDataBootstrapResponse;
@@ -27,6 +28,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -36,9 +38,15 @@ public class SampleDataBootstrapService {
 
     private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
     private static final String DEFAULT_SCENARIO = "default";
+    private static final String LARGE_SCENARIO = "large";
+    private static final int LARGE_SELLER_COUNT = 30;
+    private static final int LARGE_PRODUCT_COUNT_PER_SELLER = 20;
+    private static final int LARGE_PREVIOUS_ORDER_COUNT_PER_SELLER = 100;
+    private static final int LARGE_TARGET_ORDER_COUNT_PER_SELLER = 60;
 
     private final PipelineRunItemRepository pipelineRunItemRepository;
     private final PipelineRunRepository pipelineRunRepository;
+    private final PipelineExecutionLockRepository pipelineExecutionLockRepository;
     private final RecommendationRepository recommendationRepository;
     private final InsightRepository insightRepository;
     private final DailyMetricRepository dailyMetricRepository;
@@ -52,7 +60,7 @@ public class SampleDataBootstrapService {
     public SampleDataBootstrapResponse bootstrap(String scenario) {
         String normalizedScenario = scenario == null ? DEFAULT_SCENARIO : scenario.trim().toLowerCase();
 
-        if (!DEFAULT_SCENARIO.equals(normalizedScenario)) {
+        if (!DEFAULT_SCENARIO.equals(normalizedScenario) && !LARGE_SCENARIO.equals(normalizedScenario)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
@@ -62,6 +70,14 @@ public class SampleDataBootstrapService {
         LocalDate previousMetricDate = targetMetricDate.minusDays(1);
         LocalDate recentMetricDate = targetMetricDate.minusDays(10);
         LocalDate staleMetricDate = targetMetricDate.minusDays(20);
+
+        if (LARGE_SCENARIO.equals(normalizedScenario)) {
+            return seedLargeScenario(
+                    normalizedScenario,
+                    previousMetricDate,
+                    targetMetricDate
+            );
+        }
 
         SellerSeedResult alpha = seedAlphaSeller(
                 previousMetricDate,
@@ -105,17 +121,18 @@ public class SampleDataBootstrapService {
     }
 
     private void clearExistingData() {
-        pipelineRunItemRepository.deleteAll();
-        pipelineRunRepository.deleteAll();
-        recommendationRepository.deleteAll();
-        insightRepository.deleteAll();
-        dailyMetricRepository.deleteAll();
-        orderItemRepository.deleteAll();
-        customerOrderRepository.deleteAll();
-        productRepository.deleteAll();
-        importJobRepository.deleteAll();
-        sellerCredentialRepository.deleteAll();
-        sellerRepository.deleteAll();
+        pipelineExecutionLockRepository.deleteAllInBatch();
+        pipelineRunItemRepository.deleteAllInBatch();
+        pipelineRunRepository.deleteAllInBatch();
+        recommendationRepository.deleteAllInBatch();
+        insightRepository.deleteAllInBatch();
+        dailyMetricRepository.deleteAllInBatch();
+        orderItemRepository.deleteAllInBatch();
+        customerOrderRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        importJobRepository.deleteAllInBatch();
+        sellerCredentialRepository.deleteAllInBatch();
+        sellerRepository.deleteAllInBatch();
     }
 
     private SellerSeedResult seedAlphaSeller(
@@ -332,6 +349,126 @@ public class SampleDataBootstrapService {
         return new SellerSeedResult(seller, 2, orderCount, orderItemCount);
     }
 
+    private SampleDataBootstrapResponse seedLargeScenario(
+            String normalizedScenario,
+            LocalDate previousMetricDate,
+            LocalDate targetMetricDate
+    ) {
+        List<SampleDataSellerResponse> sellers = new ArrayList<>();
+
+        int totalProductCount = 0;
+        int totalOrderCount = 0;
+        int totalOrderItemCount = 0;
+
+        for (int sellerIndex = 1; sellerIndex <= LARGE_SELLER_COUNT; sellerIndex++) {
+            SellerSeedResult result = seedLargeSeller(
+                    sellerIndex,
+                    previousMetricDate,
+                    targetMetricDate
+            );
+
+            sellers.add(new SampleDataSellerResponse(
+                    result.seller().getId(),
+                    result.seller().getExternalSellerId(),
+                    result.seller().getSellerName(),
+                    result.productCount(),
+                    result.orderCount()
+            ));
+
+            totalProductCount += result.productCount();
+            totalOrderCount += result.orderCount();
+            totalOrderItemCount += result.orderItemCount();
+        }
+
+        return new SampleDataBootstrapResponse(
+                normalizedScenario,
+                previousMetricDate,
+                targetMetricDate,
+                sellers.size(),
+                totalProductCount,
+                totalOrderCount,
+                totalOrderItemCount,
+                sellers
+        );
+    }
+
+    private SellerSeedResult seedLargeSeller(
+            int sellerIndex,
+            LocalDate previousMetricDate,
+            LocalDate targetMetricDate
+    ) {
+        String sellerSequence = "%03d".formatted(sellerIndex);
+        Seller seller = sellerRepository.saveAndFlush(
+                Seller.create(
+                        "large-seller-" + sellerSequence,
+                        "large-store-" + sellerSequence
+                )
+        );
+
+        List<Product> products = new ArrayList<>();
+
+        for (int productIndex = 1; productIndex <= LARGE_PRODUCT_COUNT_PER_SELLER; productIndex++) {
+            String productSequence = "%03d".formatted(productIndex);
+            boolean soldOut = productIndex <= 3;
+
+            products.add(Product.create(
+                    seller,
+                    seller.getExternalSellerId() + "-PROD-" + productSequence,
+                    "Large 상품 " + sellerSequence + "-" + productSequence,
+                    new BigDecimal("20000"),
+                    soldOut ? 0 : 100 + productIndex,
+                    soldOut ? "SOLD_OUT" : "ON_SALE",
+                    importedAt(previousMetricDate)
+            ));
+        }
+
+        List<Product> savedProducts = productRepository.saveAll(products);
+
+        int orderCount = 0;
+        int orderItemCount = 0;
+
+        for (int sequence = 1; sequence <= LARGE_PREVIOUS_ORDER_COUNT_PER_SELLER; sequence++) {
+            Product product = savedProducts.get((sequence - 1) % 10);
+
+            createLargeSingleItemOrder(
+                    seller,
+                    product,
+                    previousMetricDate,
+                    "PREV",
+                    sequence,
+                    1,
+                    new BigDecimal("20000")
+            );
+
+            orderCount++;
+            orderItemCount++;
+        }
+
+        for (int sequence = 1; sequence <= LARGE_TARGET_ORDER_COUNT_PER_SELLER; sequence++) {
+            Product product = savedProducts.get(3 + ((sequence - 1) % 7));
+
+            createLargeSingleItemOrder(
+                    seller,
+                    product,
+                    targetMetricDate,
+                    "TARGET",
+                    sequence,
+                    1,
+                    new BigDecimal("10000")
+            );
+
+            orderCount++;
+            orderItemCount++;
+        }
+
+        return new SellerSeedResult(
+                seller,
+                LARGE_PRODUCT_COUNT_PER_SELLER,
+                orderCount,
+                orderItemCount
+        );
+    }
+
     private void createSingleItemOrder(
             Seller seller,
             Product product,
@@ -361,6 +498,42 @@ public class SampleDataBootstrapService {
                         customerOrder,
                         product,
                         seller.getExternalSellerId() + "-ITEM-" + sequence + "-" + orderDate,
+                        quantity,
+                        unitPrice,
+                        itemAmount
+                )
+        );
+    }
+
+    private void createLargeSingleItemOrder(
+            Seller seller,
+            Product product,
+            LocalDate orderDate,
+            String orderGroup,
+            int sequence,
+            int quantity,
+            BigDecimal unitPrice
+    ) {
+        BigDecimal itemAmount = unitPrice.multiply(BigDecimal.valueOf(quantity));
+        OffsetDateTime orderedAt = orderDate.atTime(sequence % 24, sequence % 60)
+                .atZone(ASIA_SEOUL)
+                .toOffsetDateTime();
+
+        CustomerOrder customerOrder = customerOrderRepository.save(
+                CustomerOrder.create(
+                        seller,
+                        seller.getExternalSellerId() + "-ORD-" + orderGroup + "-" + sequence,
+                        orderedAt,
+                        "PAID",
+                        itemAmount
+                )
+        );
+
+        orderItemRepository.save(
+                OrderItem.create(
+                        customerOrder,
+                        product,
+                        seller.getExternalSellerId() + "-ITEM-" + orderGroup + "-" + sequence,
                         quantity,
                         unitPrice,
                         itemAmount

--- a/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
+++ b/src/test/java/com/sellerinsight/sampledata/api/AdminSampleDataControllerTest.java
@@ -126,7 +126,8 @@ class AdminSampleDataControllerTest {
                 .andExpect(jsonPath("$.data.processedSellerCount").value(2))
                 .andExpect(jsonPath("$.data.failedSellerCount").value(0))
                 .andExpect(jsonPath("$.data.generatedInsightCount").value(3))
-                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.durationMs").isNumber());
 
         Seller alphaSeller = sellerRepository.findAll().stream()
                 .filter(seller -> "sample-seller-alpha".equals(seller.getExternalSellerId()))
@@ -164,7 +165,8 @@ class AdminSampleDataControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.length()").value(1))
                 .andExpect(jsonPath("$.data[0].metricDate").value(targetMetricDate.toString()))
-                .andExpect(jsonPath("$.data[0].status").value("SUCCESS"));
+                .andExpect(jsonPath("$.data[0].status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].durationMs").isNumber());
 
         Long runId = pipelineRunRepository.findAllByPipelineTypeOrderByIdDesc(
                 com.sellerinsight.pipeline.domain.PipelineType.DAILY
@@ -175,7 +177,28 @@ class AdminSampleDataControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.run.durationMs").isNumber())
                 .andExpect(jsonPath("$.data.itemCount").value(2))
-                .andExpect(jsonPath("$.data.items.length()").value(2));
+                .andExpect(jsonPath("$.data.items.length()").value(2))
+                .andExpect(jsonPath("$.data.items[0].durationMs").isNumber());
+    }
+
+    @Test
+    void bootstrapLargeSampleData() throws Exception {
+        LocalDate targetMetricDate = LocalDate.now(ASIA_SEOUL).minusDays(1);
+
+        mockMvc.perform(
+                        post("/api/v1/admin/sample-data/bootstrap")
+                                .param("scenario", "large")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.scenario").value("large"))
+                .andExpect(jsonPath("$.data.targetMetricDate").value(targetMetricDate.toString()))
+                .andExpect(jsonPath("$.data.sellerCount").value(30))
+                .andExpect(jsonPath("$.data.productCount").value(600))
+                .andExpect(jsonPath("$.data.orderCount").value(4800))
+                .andExpect(jsonPath("$.data.orderItemCount").value(4800))
+                .andExpect(jsonPath("$.data.sellers.length()").value(30));
     }
 }


### PR DESCRIPTION
## 유형
- [ ] BUG
- [x] TEST
- [ ] FEAT
- [ ] TASK

## 작업 요약
일별 파이프라인 성능 개선 전후 비교를 위해 전체 실행 시간과 판매자별 처리 시간을 응답으로 노출하고, large 샘플 데이터 시나리오를 추가했습니다.

## 주요 변경점
- PipelineRun, PipelineRunItem에 durationMs 계산 필드 추가
- 파이프라인 실행/목록/상세 응답 DTO에 durationMs 추가
- scenario=large 샘플 데이터 추가
- 샘플 데이터 초기화 로직을 deleteAllInBatch 기반으로 보강
- AdminSampleDataControllerTest에 durationMs 및 large 시나리오 검증 추가

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #29 