### PR TITLE
[FEAT] 일별 집계 파이프라인 성능 최적화

### DIFF
--- a/src/main/java/com/sellerinsight/metric/application/DailyMetricAggregationService.java
+++ b/src/main/java/com/sellerinsight/metric/application/DailyMetricAggregationService.java
@@ -5,10 +5,8 @@ import com.sellerinsight.common.error.ErrorCode;
 import com.sellerinsight.metric.api.dto.DailyMetricResponse;
 import com.sellerinsight.metric.domain.DailyMetric;
 import com.sellerinsight.metric.domain.DailyMetricRepository;
-import com.sellerinsight.order.domain.CustomerOrder;
 import com.sellerinsight.order.domain.CustomerOrderRepository;
-import com.sellerinsight.order.domain.OrderItemRepository;
-import com.sellerinsight.product.domain.Product;
+import com.sellerinsight.order.domain.DailyOrderSummary;
 import com.sellerinsight.product.domain.ProductRepository;
 import com.sellerinsight.seller.domain.Seller;
 import com.sellerinsight.seller.domain.SellerRepository;
@@ -21,8 +19,6 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.util.List;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +31,6 @@ public class DailyMetricAggregationService {
     private final DailyMetricRepository dailyMetricRepository;
     private final ProductRepository productRepository;
     private final CustomerOrderRepository customerOrderRepository;
-    private final OrderItemRepository orderItemRepository;
 
     @Transactional
     public DailyMetricResponse aggregate(Long sellerId, LocalDate metricDate) {
@@ -45,17 +40,14 @@ public class DailyMetricAggregationService {
         OffsetDateTime dayStart = metricDate.atStartOfDay(ASIA_SEOUL).toOffsetDateTime();
         OffsetDateTime nextDayStart = metricDate.plusDays(1).atStartOfDay(ASIA_SEOUL).toOffsetDateTime();
 
-        List<CustomerOrder> orders = customerOrderRepository
-                .findAllBySellerIdAndOrderedAtGreaterThanEqualAndOrderedAtLessThan(
-                        sellerId,
-                        dayStart,
-                        nextDayStart
-                );
+        DailyOrderSummary orderSummary = customerOrderRepository.summarizeDailyOrders(
+                sellerId,
+                dayStart,
+                nextDayStart
+        );
 
-        int orderCount = orders.size();
-        BigDecimal salesAmount = orders.stream()
-                .map(CustomerOrder::getTotalAmount)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        int orderCount = orderSummary.orderCountAsInt();
+        BigDecimal salesAmount = orderSummary.salesAmountOrZero();
 
         BigDecimal averageOrderAmount = orderCount == 0
                 ? BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
@@ -70,16 +62,13 @@ public class DailyMetricAggregationService {
                 .atStartOfDay(ASIA_SEOUL)
                 .toOffsetDateTime();
 
-        Set<Long> recentlySoldProductIds = orderItemRepository.findDistinctProductIdsBySellerIdAndOrderedAtBetween(
-                sellerId,
-                staleWindowStart,
-                nextDayStart
+        int staleProductCount = Math.toIntExact(
+                productRepository.countStaleProductsBySellerIdAndOrderedAtBetween(
+                        sellerId,
+                        staleWindowStart,
+                        nextDayStart
+                )
         );
-
-        int staleProductCount = (int) productRepository.findAllBySellerId(sellerId).stream()
-                .map(Product::getId)
-                .filter(productId -> !recentlySoldProductIds.contains(productId))
-                .count();
 
         DailyMetric dailyMetric = dailyMetricRepository.findBySellerIdAndMetricDate(sellerId, metricDate)
                 .map(existingMetric -> {

--- a/src/main/java/com/sellerinsight/order/domain/CustomerOrderRepository.java
+++ b/src/main/java/com/sellerinsight/order/domain/CustomerOrderRepository.java
@@ -1,18 +1,29 @@
 package com.sellerinsight.order.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface CustomerOrderRepository extends JpaRepository<CustomerOrder, Long> {
 
     Optional<CustomerOrder> findBySellerIdAndExternalOrderNo(Long sellerId, String externalOrderNo);
 
-    List<CustomerOrder> findAllBySellerIdAndOrderedAtGreaterThanEqualAndOrderedAtLessThan(
-            Long sellerId,
-            OffsetDateTime start,
-            OffsetDateTime end
+    @Query("""
+            select new com.sellerinsight.order.domain.DailyOrderSummary(
+                count(o),
+                sum(o.totalAmount)
+            )
+            from CustomerOrder o
+            where o.seller.id = :sellerId
+              and o.orderedAt >= :start
+              and o.orderedAt < :end
+            """)
+    DailyOrderSummary summarizeDailyOrders(
+            @Param("sellerId") Long sellerId,
+            @Param("start") OffsetDateTime start,
+            @Param("end") OffsetDateTime end
     );
 }

--- a/src/main/java/com/sellerinsight/order/domain/DailyOrderSummary.java
+++ b/src/main/java/com/sellerinsight/order/domain/DailyOrderSummary.java
@@ -1,0 +1,21 @@
+package com.sellerinsight.order.domain;
+
+import java.math.BigDecimal;
+
+public record DailyOrderSummary(
+        Long orderCount,
+        BigDecimal salesAmount
+) {
+
+    public int orderCountAsInt() {
+        if (orderCount == null) {
+            return 0;
+        }
+
+        return Math.toIntExact(orderCount);
+    }
+
+    public BigDecimal salesAmountOrZero() {
+        return salesAmount == null ? BigDecimal.ZERO : salesAmount;
+    }
+}

--- a/src/main/java/com/sellerinsight/product/domain/ProductRepository.java
+++ b/src/main/java/com/sellerinsight/product/domain/ProductRepository.java
@@ -1,15 +1,35 @@
 package com.sellerinsight.product.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.List;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Optional<Product> findBySellerIdAndExternalProductId(Long sellerId, String externalProductid);
 
-    List<Product> findAllBySellerId(Long sellerId);
-
     long countBySellerIdAndStockQuantityLessThanEqual(Long sellerId, Integer stockQuantity);
+
+    @Query("""
+            select count(p)
+            from Product p
+            where p.seller.id = :sellerId
+              and not exists (
+                  select oi.id
+                  from OrderItem oi
+                  join oi.customerOrder o
+                  where oi.product.id = p.id
+                    and o.seller.id = :sellerId
+                    and o.orderedAt >= :start
+                    and o.orderedAt < :end
+              )
+            """)
+    long countStaleProductsBySellerIdAndOrderedAtBetween(
+            @Param("sellerId") Long sellerId,
+            @Param("start") OffsetDateTime start,
+            @Param("end") OffsetDateTime end
+    );
 }

--- a/src/main/resources/db/migration/V11__add_pipeline_metric_performance_indexes.sql
+++ b/src/main/resources/db/migration/V11__add_pipeline_metric_performance_indexes.sql
@@ -1,0 +1,8 @@
+create index idx_orders_seller_id_ordered_at
+    on orders (seller_id, ordered_at);
+
+create index idx_products_seller_id_stock_quantity
+    on products (seller_id, stock_quantity);
+
+create index idx_order_items_product_id_order_id
+    on order_items (product_id, order_id);


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [x] FEAT
- [ ] TASK

## 작업 요약
일별 집계 파이프라인에서 주문/상품 엔티티를 로딩해 Java에서 계산하던 병목을 DB 집계 쿼리와 인덱스 기반 count 쿼리로 개선했습니다.

## 주요 변경점
- DailyOrderSummary projection 추가
- 주문 수/매출 합계를 CustomerOrderRepository 집계 쿼리로 계산
- 장기 미판매 상품 수를 ProductRepository의 not exists 기반 count 쿼리로 계산
- orders, products, order_items 조회 경로에 성능 개선 인덱스 추가
- DailyMetricAggregationService에서 불필요한 엔티티 목록 로딩 제거

## 성능 측정
- BEFORE 평균: 3,118.3ms
- AFTER 평균: 875.7ms
- 개선율: 약 71.9%
- 측정 조건: large 시나리오, 판매자 30명, 상품 600개, 주문 4,800건
- 기능 결과 유지: generatedInsightCount 120, failedSellerCount 0

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #31 