### PR TITLE
[TASK] 일별 파이프라인 모니터링 지표 및 Grafana 대시보드 구축

### DIFF
--- a/monitoring/grafana/dashboards/sellerinsight-daily-pipeline.json
+++ b/monitoring/grafana/dashboards/sellerinsight-daily-pipeline.json
@@ -1,0 +1,781 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_runs_total{application=\"sellerinsight\"}[$__range]))",
+          "legendFormat": "runs",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pipeline Runs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_runs_total{application=\"sellerinsight\",status=\"SUCCESS\"}[$__range]))",
+          "legendFormat": "success",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Successful Runs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_runs_total{application=\"sellerinsight\",status!=\"SUCCESS\"}[$__range]))",
+          "legendFormat": "failed",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Runs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_duration_seconds_sum{application=\"sellerinsight\"}[$__range])) / clamp_min(sum(increase(daily_pipeline_duration_seconds_count{application=\"sellerinsight\"}[$__range])), 1)",
+          "legendFormat": "avg-duration",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_processed_sellers_total{application=\"sellerinsight\"}[$__range]))",
+          "legendFormat": "processed-sellers",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Processed Sellers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_generated_insights_total{application=\"sellerinsight\"}[$__range]))",
+          "legendFormat": "generated-insights",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Generated Insights",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_failed_sellers_total{application=\"sellerinsight\"}[$__range]))",
+          "legendFormat": "failed-sellers",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Sellers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(daily_pipeline_duration_seconds_max{application=\"sellerinsight\"})",
+          "legendFormat": "max-duration",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Max Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (increase(daily_pipeline_runs_total{application=\"sellerinsight\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pipeline Runs by Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(daily_pipeline_duration_seconds_sum{application=\"sellerinsight\"}[$__rate_interval])) / clamp_min(sum(rate(daily_pipeline_duration_seconds_count{application=\"sellerinsight\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "avg-duration",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(daily_pipeline_duration_seconds_max{application=\"sellerinsight\"})",
+          "legendFormat": "max-duration",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pipeline Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_processed_sellers_total{application=\"sellerinsight\"}[$__rate_interval]))",
+          "legendFormat": "processed-sellers",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_failed_sellers_total{application=\"sellerinsight\"}[$__rate_interval]))",
+          "legendFormat": "failed-sellers",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Seller Processing",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(daily_pipeline_generated_insights_total{application=\"sellerinsight\"}[$__rate_interval]))",
+          "legendFormat": "generated-insights",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Generated Insights",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "tags": [
+    "sellerinsight",
+    "pipeline",
+    "daily"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "SellerInsight Daily Pipeline",
+  "uid": "sellerinsight-daily-pipeline",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/alerting/daily-pipeline-alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/daily-pipeline-alerts.yml
@@ -1,0 +1,235 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: daily-pipeline-alerts
+    folder: Seller Insight
+    interval: 1m
+    rules:
+      - uid: daily-pipeline-failed-run
+        title: Daily pipeline failed run detected
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: Prometheus
+            queryType: ""
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              editorMode: code
+              expr: sum(increase(daily_pipeline_runs_total{application="sellerinsight",status!="SUCCESS"}[15m]))
+              instant: true
+              intervalMs: 1000
+              legendFormat: failed-runs
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: sellerinsight-daily-pipeline
+        panelId: 3
+        noDataState: OK
+        execErrState: Error
+        for: 1m
+        annotations:
+          summary: Daily pipeline failed run detected
+          description: One or more daily pipeline runs ended with a non-success status during the last 15 minutes.
+        labels:
+          service: sellerinsight
+          severity: critical
+
+      - uid: daily-pipeline-seller-failures
+        title: Daily pipeline seller failures detected
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: Prometheus
+            queryType: ""
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              editorMode: code
+              expr: sum(increase(daily_pipeline_failed_sellers_total{application="sellerinsight"}[15m]))
+              instant: true
+              intervalMs: 1000
+              legendFormat: failed-sellers
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: sellerinsight-daily-pipeline
+        panelId: 7
+        noDataState: OK
+        execErrState: Error
+        for: 1m
+        annotations:
+          summary: Daily pipeline seller-level failures detected
+          description: At least one seller failed during daily pipeline processing in the last 15 minutes.
+        labels:
+          service: sellerinsight
+          severity: warning
+
+      - uid: daily-pipeline-duration-regression
+        title: Daily pipeline duration regression
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: Prometheus
+            queryType: ""
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              editorMode: code
+              expr: sum(increase(daily_pipeline_duration_seconds_sum{application="sellerinsight"}[15m])) / clamp_min(sum(increase(daily_pipeline_duration_seconds_count{application="sellerinsight"}[15m])), 1)
+              instant: true
+              intervalMs: 1000
+              legendFormat: avg-duration
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 2
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: sellerinsight-daily-pipeline
+        panelId: 4
+        noDataState: OK
+        execErrState: Error
+        for: 2m
+        annotations:
+          summary: Daily pipeline execution became slower than expected
+          description: Average daily pipeline duration over the last 15 minutes exceeded 2 seconds.
+        labels:
+          service: sellerinsight
+          severity: warning

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -2,10 +2,18 @@ apiVersion: 1
 
 prune: true
 
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+  - name: Loki
+    orgId: 1
+
 datasources:
   - name: Prometheus
+    uid: Prometheus
     type: prometheus
     access: proxy
+    orgId: 1
     url: http://prometheus:9090
     isDefault: true
     editable: false
@@ -13,7 +21,9 @@ datasources:
       httpMethod: POST
 
   - name: Loki
+    uid: Loki
     type: loki
     access: proxy
+    orgId: 1
     url: http://loki:3100
     editable: false

--- a/src/main/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionService.java
+++ b/src/main/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionService.java
@@ -37,6 +37,7 @@ public class DailyPipelineExecutionService {
     private final PipelineRunRepository pipelineRunRepository;
     private final PipelineRunItemRepository pipelineRunItemRepository;
     private final PipelineExecutionLockRepository pipelineExecutionLockRepository;
+    private final PipelineMetricsRecorder pipelineMetricsRecorder;
 
     @Value("${app.pipeline.daily.lock-timeout-minutes:30}")
     private long lockTimeoutMinutes;
@@ -158,6 +159,8 @@ public class DailyPipelineExecutionService {
             );
 
             PipelineRun savedPipelineRun = pipelineRunRepository.saveAndFlush(pipelineRun);
+
+            pipelineMetricsRecorder.recordDailyPipelineRun(savedPipelineRun);
 
             return DailyPipelineRunResponse.from(savedPipelineRun, failedSellerIds);
 

--- a/src/main/java/com/sellerinsight/pipeline/application/PipelineMetricsRecorder.java
+++ b/src/main/java/com/sellerinsight/pipeline/application/PipelineMetricsRecorder.java
@@ -1,0 +1,63 @@
+package com.sellerinsight.pipeline.application;
+
+import com.sellerinsight.pipeline.domain.PipelineRun;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class PipelineMetricsRecorder {
+
+    private final MeterRegistry meterRegistry;
+
+    public void recordDailyPipelineRun(PipelineRun pipelineRun) {
+        String pipelineType = pipelineRun.getPipelineType().name();
+        String triggerType = pipelineRun.getTriggerType().name();
+        String status = pipelineRun.getStatus().name();
+
+        Counter.builder("daily.pipeline.runs")
+                .description("Total daily pipeline runs")
+                .tag("pipeline_type", pipelineType)
+                .tag("trigger_type", triggerType)
+                .tag("status", status)
+                .register(meterRegistry)
+                .increment();
+
+        Timer.builder("daily.pipeline.duration")
+                .description("Daily pipeline execution duration")
+                .tag("pipeline_type", pipelineType)
+                .tag("trigger_type", triggerType)
+                .tag("status", status)
+                .register(meterRegistry)
+                .record(Duration.ofMillis(Math.max(pipelineRun.getDurationMs(), 0L)));
+
+        Counter.builder("daily.pipeline.processed.sellers")
+                .description("Total processed sellers in daily pipeline")
+                .tag("pipeline_type", pipelineType)
+                .tag("trigger_type", triggerType)
+                .tag("status", status)
+                .register(meterRegistry)
+                .increment(pipelineRun.getProcessedSellerCount());
+
+        Counter.builder("daily.pipeline.failed.sellers")
+                .description("Total failed sellers in daily pipeline")
+                .tag("pipeline_type", pipelineType)
+                .tag("trigger_type", triggerType)
+                .tag("status", status)
+                .register(meterRegistry)
+                .increment(pipelineRun.getFailedSellerCount());
+
+        Counter.builder("daily.pipeline.generated.insights")
+                .description("Total generated insights in daily pipeline")
+                .tag("pipeline_type", pipelineType)
+                .tag("trigger_type", triggerType)
+                .tag("status", status)
+                .register(meterRegistry)
+                .increment(pipelineRun.getGeneratedInsightCount());
+    }
+}

--- a/src/test/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionServiceTest.java
+++ b/src/test/java/com/sellerinsight/pipeline/application/DailyPipelineExecutionServiceTest.java
@@ -65,6 +65,9 @@ class DailyPipelineExecutionServiceTest {
     @Mock
     private PipelineExecutionLockRepository pipelineExecutionLockRepository;
 
+    @Mock
+    private PipelineMetricsRecorder pipelineMetricsRecorder;
+
     @Test
     void runProcessesConnectedSellersAndContinuesOnFailure() {
         Seller seller1 = mock(Seller.class);
@@ -122,6 +125,7 @@ class DailyPipelineExecutionServiceTest {
         verify(insightGenerationService, never()).generate(2L, metricDate);
         verify(pipelineRunRepository, times(2)).saveAndFlush(any(PipelineRun.class));
         verify(pipelineRunItemRepository, times(2)).save(any(PipelineRunItem.class));
+        verify(pipelineMetricsRecorder).recordDailyPipelineRun(any(PipelineRun.class));
     }
 
     @Test
@@ -150,7 +154,8 @@ class DailyPipelineExecutionServiceTest {
                 dailyMetricAggregationService,
                 insightGenerationService,
                 pipelineRunRepository,
-                pipelineRunItemRepository
+                pipelineRunItemRepository,
+                pipelineMetricsRecorder
         );
     }
 
@@ -197,6 +202,7 @@ class DailyPipelineExecutionServiceTest {
                 .deleteByPipelineTypeAndMetricDate(PipelineType.DAILY, metricDate);
         verify(pipelineRunRepository)
                 .findFirstByPipelineTypeAndMetricDateOrderByIdDesc(PipelineType.DAILY, metricDate);
+        verify(pipelineMetricsRecorder).recordDailyPipelineRun(any(PipelineRun.class));
     }
 
     private DailyPipelineExecutionService createServiceWithTimeout(long timeoutMinutes) {
@@ -206,7 +212,8 @@ class DailyPipelineExecutionServiceTest {
                 insightGenerationService,
                 pipelineRunRepository,
                 pipelineRunItemRepository,
-                pipelineExecutionLockRepository
+                pipelineExecutionLockRepository,
+                pipelineMetricsRecorder
         );
 
         ReflectionTestUtils.setField(service, "lockTimeoutMinutes", timeoutMinutes);

--- a/src/test/java/com/sellerinsight/pipeline/application/PipelineMetricsRecorderTest.java
+++ b/src/test/java/com/sellerinsight/pipeline/application/PipelineMetricsRecorderTest.java
@@ -1,0 +1,47 @@
+package com.sellerinsight.pipeline.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sellerinsight.pipeline.domain.PipelineRun;
+import com.sellerinsight.pipeline.domain.PipelineRunStatus;
+import com.sellerinsight.pipeline.domain.PipelineTriggerType;
+import com.sellerinsight.pipeline.domain.PipelineType;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class PipelineMetricsRecorderTest {
+
+    @Test
+    void recordDailyPipelineRun() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        PipelineMetricsRecorder recorder = new PipelineMetricsRecorder(meterRegistry);
+
+        PipelineRun pipelineRun = PipelineRun.start(
+                PipelineType.DAILY,
+                PipelineTriggerType.MANUAL,
+                LocalDate.of(2026, 4, 20)
+        );
+
+        pipelineRun.complete(
+                PipelineRunStatus.SUCCESS,
+                30,
+                30,
+                0,
+                120
+        );
+
+        recorder.recordDailyPipelineRun(pipelineRun);
+
+        assertThat(meterRegistry.get("daily.pipeline.runs").counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("daily.pipeline.processed.sellers").counter().count()).isEqualTo(30.0);
+        assertThat(meterRegistry.get("daily.pipeline.failed.sellers").counter().count()).isEqualTo(0.0);
+        assertThat(meterRegistry.get("daily.pipeline.generated.insights").counter().count()).isEqualTo(120.0);
+
+        Timer durationTimer = meterRegistry.get("daily.pipeline.duration").timer();
+        assertThat(durationTimer.count()).isEqualTo(1);
+        assertThat(durationTimer.totalTime(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(0.0);
+    }
+}


### PR DESCRIPTION
## 유형
- [ ] BUG
- [ ] TEST
- [ ] FEAT
- [x] TASK

## 작업 요약
- 일별 파이프라인 실행 결과를 Micrometer custom metric으로 발행하고, Prometheus-Grafana 기반 운영 관측성을 구성했습니다.

## 주요 변경점
- 일별 파이프라인 실행 횟수, 처리 판매자 수, 실패 판매자 수, 생성 인사이트 수, 실행 시간 metric 추가
- 파이프라인 완료 후 `PipelineRun` 결과 기반으로 metric을 기록하도록 서비스 연동
- `PipelineMetricsRecorderTest` 및 기존 파이프라인 실행 서비스 테스트 보강
- Grafana datasource UID 고정 및 기존 datasource 충돌 방지 설정 추가
- `SellerInsight Daily Pipeline` Grafana dashboard provisioning 추가
- 파이프라인 실패, 판매자 단위 실패, 실행 시간 증가 alert rule provisioning 추가

## 테스트
- [ ] 실행하지 않음
- [x] `./gradlew test`
- [x] 수동 확인

## 이슈
- Closes #33 